### PR TITLE
Bugfix/corrected/session window handling

### DIFF
--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -1027,6 +1027,11 @@ class CollaborativeClosureTests(TestCase):
             0,
         )
 
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Window closed")
+        self.assertTemplateUsed(response, "synopsis/collaborative_editor.html")
+
         start_url = reverse(
             "synopsis:collaborative_start",
             args=[self.project.id, "protocol"],

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1989,6 +1989,7 @@ def protocol_detail(request, project_id):
     )
 
     collaborative_enabled = _onlyoffice_enabled()
+    protocol_closed = bool(protocol and protocol.feedback_closed_at)
     collaborative_session = None
     collaborative_resume_url = ""
     collaborative_force_end_url = ""
@@ -1997,6 +1998,12 @@ def protocol_detail(request, project_id):
         collaborative_session = _get_active_collaborative_session(
             project, CollaborativeSession.DOCUMENT_PROTOCOL
         )
+        if collaborative_session and protocol_closed:
+            collaborative_session.mark_inactive(
+                ended_by=request.user if request.user.is_authenticated else None,
+                reason="Protocol feedback window closed",
+            )
+            collaborative_session = None
         if collaborative_session:
             collaborative_resume_url = reverse(
                 "synopsis:collaborative_edit",
@@ -2011,6 +2018,12 @@ def protocol_detail(request, project_id):
             request.user, project, collaborative_session
         )
     else:
+        collaborative_can_override = False
+    if protocol_closed:
+        collaborative_enabled = False
+        collaborative_session = None
+        collaborative_resume_url = ""
+        collaborative_force_end_url = ""
         collaborative_can_override = False
 
     if request.method == "POST":
@@ -2270,6 +2283,7 @@ def action_list_detail(request, project_id):
     )
 
     collaborative_enabled = _onlyoffice_enabled()
+    action_closed = bool(action_list and action_list.feedback_closed_at)
     collaborative_session = None
     collaborative_resume_url = ""
     collaborative_force_end_url = ""
@@ -2278,6 +2292,12 @@ def action_list_detail(request, project_id):
         collaborative_session = _get_active_collaborative_session(
             project, CollaborativeSession.DOCUMENT_ACTION_LIST
         )
+        if collaborative_session and action_closed:
+            collaborative_session.mark_inactive(
+                ended_by=request.user if request.user.is_authenticated else None,
+                reason="Action list feedback window closed",
+            )
+            collaborative_session = None
         if collaborative_session:
             collaborative_resume_url = reverse(
                 "synopsis:collaborative_edit",
@@ -2292,6 +2312,12 @@ def action_list_detail(request, project_id):
             request.user, project, collaborative_session
         )
     else:
+        collaborative_can_override = False
+    if action_closed:
+        collaborative_enabled = False
+        collaborative_session = None
+        collaborative_resume_url = ""
+        collaborative_force_end_url = ""
         collaborative_can_override = False
 
     if request.method == "POST":

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -3,7 +3,10 @@
 {% block page_container_class %}container-fluid p-0{% endblock %}
 {% block content %}
 // TODO: #42 It seems there is a bug when closing the window does not close the interactive collab session on onlyoffice server. Need to handle this so when closed the session is closed properly and no edits are made.
-
+// TODO: #45 # Need to consider handling reconnecting to the session if the user loses connection temporarily.
+// TODO: #46 need to consider adding a notice about autosave and how often changes are saved.
+// TODO: #47 close to issue 42, the message to show if window is closed without ending the session properly is not displaying. Need to investigate further.
+// TODO: #44 need to consider adding a warning when the user attempts to close the tab/window while editing.
 <div class="collab-header py-3 px-3 px-md-4">
     <h1 class="mb-2">Collaborative editor – {{ document_label }}</h1>
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -2,10 +2,8 @@
 {% block title %}Collaborative Editor – {{ document_label }}{% endblock %}
 {% block page_container_class %}container-fluid p-0{% endblock %}
 {% block content %}
-// TODO: #42 It seems there is a bug when closing the window does not close the interactive collab session on onlyoffice server. Need to handle this so when closed the session is closed properly and no edits are made.
 // TODO: #45 # Need to consider handling reconnecting to the session if the user loses connection temporarily.
 // TODO: #46 need to consider adding a notice about autosave and how often changes are saved.
-// TODO: #47 close to issue 42, the message to show if window is closed without ending the session properly is not displaying. Need to investigate further.
 // TODO: #44 need to consider adding a warning when the user attempts to close the tab/window while editing.
 <div class="collab-header py-3 px-3 px-md-4">
     <h1 class="mb-2">Collaborative editor – {{ document_label }}</h1>

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -30,6 +30,11 @@
     <div class="small text-muted mt-2">You are editing as {{ participant_display }}.</div>
     {% endif %}
 </div>
+{% if window_closed_message %}
+<div class="alert alert-warning mx-3 mx-md-4 mt-3" role="alert">
+    {{ window_closed_message }}
+</div>
+{% endif %}
 <style>
   #onlyoffice-editor {
     width: 100%;
@@ -46,6 +51,7 @@
     }
   }
 </style>
+{% if editor_config %}
 <div id="onlyoffice-editor"></div>
 {{ editor_config|json_script:"onlyoffice-editor-config" }}
 <script src="{{ onlyoffice_js_url }}"></script>
@@ -115,4 +121,9 @@
         }
     })();
 </script>
+{% elif not window_closed_message %}
+<div class="p-4 text-muted">
+    Collaborative editing is currently unavailable.
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
# Pull Request
<!-- Please fill out the following sections to the best of your ability. You may skip any sections that are not mandatory or relevant by putting 'N/A' inside the sub-section. -->

_Please answer the following sections before submitting your PR:_

## Type of Change
<!-- Mandatory -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues
<!-- Mandatory -->
Fixes #47, #42.

#### 1 Why was this PR needed?
This PR adds functionality to close collaborative editing sessions when the protocol or action list feedback window is closed. When the feedback window is closed, any active collaborative sessions are automatically ended, and users accessing the collaborative editor are shown a closure message instead of the editor interface. It solves a bug encountered during testing.

#### 2 What changed?
Key changes:

- Collaborative sessions are now automatically ended when feedback windows are closed
- Users accessing a collaborative editor for a closed feedback window see a closure message instead of the editor
- Inactive sessions can automatically restart if the user has edit permissions and the feedback window is reopened

#### 3 Backward compatibility & risk
N/A

#### 4 Files changed
Files `views.py`, `tests.py`, and `collaborative_editor.html`. 

#### 5 Other changes
Added a few TODOs related to this feature.

## Testing & Results
<!-- Mandatory -->
All tests ran successfully and modified a few cases where they were not capturing the desired functionality for testing. 

## Checklist
<!-- Mandatory -->
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my changes work
- [x] All new and existing tests pass
- [x] My changes follow the established code style guidelines

## Screenshots (if applicable)
<!-- Optional -->
Fix proof: Now, if the session is closed for further collaboration, it is displayed clearly.
<img width="1724" height="943" alt="Screenshot 2025-10-31 at 21 27 19" src="https://github.com/user-attachments/assets/372c0e53-474d-4840-b8e3-06ad11e95401" />

## Notes for reviewers
<!-- Optional -->
Ignore the TODO shown in the screenshot above :).