### PR TITLE
Enhancement/online pilot onlyoffice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.venv
+.vscode
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.env
+src/media
+src/staticfiles
+*.sqlite3

--- a/.env.local.template
+++ b/.env.local.template
@@ -1,0 +1,42 @@
+# Local non-Docker development environment
+# Copy this file to `.env.local`.
+# Direct Django commands will automatically prefer `.env.local` over `.env`.
+
+SECRET_KEY=your-local-secret-key-here
+DEBUG=True
+
+DB_NAME=ce_portal
+DB_USER=ce_user
+DB_PASSWORD=ce_pass
+DB_HOST=localhost
+DB_PORT=5432
+
+ALLOWED_HOSTS=localhost,127.0.0.1
+CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://127.0.0.1:8000
+SERVE_MEDIA=False
+
+EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+EMAIL_HOST=localhost
+EMAIL_PORT=25
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+EMAIL_USE_TLS=False
+EMAIL_USE_SSL=False
+EMAIL_TIMEOUT=10
+DEFAULT_FROM_EMAIL=CE Synopsis Portal <ce-portal@localhost>
+SERVER_EMAIL=CE Synopsis Portal <ce-portal@localhost>
+
+USE_X_FORWARDED_HOST=False
+USE_X_FORWARDED_PORT=False
+SECURE_PROXY_SSL_HEADER_ENABLED=False
+SESSION_COOKIE_SECURE=False
+CSRF_COOKIE_SECURE=False
+SECURE_SSL_REDIRECT=False
+
+# Optional for local OnlyOffice testing without Docker.
+ONLYOFFICE_URL=http://localhost:8080
+ONLYOFFICE_INTERNAL_URL=
+ONLYOFFICE_APP_BASE_URL=
+ONLYOFFICE_JWT_SECRET=change-me
+ONLYOFFICE_CALLBACK_TIMEOUT=10
+ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=http://localhost:8080

--- a/.env.template
+++ b/.env.template
@@ -3,11 +3,18 @@
 # NEVER commit your .env file!
 
 # Django secret key – generate your own using command:
-# python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
-SECRET_KEY= your-secret-key-here -- dont forget!!!
+# python -c 'import secrets; print(secrets.token_urlsafe(50))'
+# If you use Docker Compose and your chosen value contains `$`, escape it as `$$`.
+SECRET_KEY=your-secret-key-here
 
 # Debug mode (True for development only)
 DEBUG=True
+
+# Runtime ports for Docker Compose
+WEB_BIND_HOST=0.0.0.0
+WEB_PORT=8000
+ONLYOFFICE_BIND_HOST=0.0.0.0
+ONLYOFFICE_PORT=8080
 
 # PostgreSQL database config
 DB_NAME=ce_portal
@@ -15,3 +22,62 @@ DB_USER=ce_user
 DB_PASSWORD=ce_pass
 DB_HOST=localhost
 DB_PORT=5432
+
+# Django host / origin config
+ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal
+CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://host.docker.internal:8000
+
+# Set to True when the Django container should serve uploaded media itself.
+SERVE_MEDIA=False
+
+# Email delivery
+# Keep the console backend for local-only testing, or switch to SMTP for a real
+# hosted pilot where invite/review emails must actually send.
+EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+EMAIL_HOST=localhost
+EMAIL_PORT=25
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+EMAIL_USE_TLS=False
+EMAIL_USE_SSL=False
+EMAIL_TIMEOUT=10
+DEFAULT_FROM_EMAIL=CE Synopsis Portal <ce-portal@localhost>
+SERVER_EMAIL=CE Synopsis Portal <ce-portal@localhost>
+
+# Reverse proxy / HTTPS settings
+# Leave these False if you are exposing Django directly over HTTP for a short
+# internal test. Turn them on only when the app is behind HTTPS on a proxy.
+USE_X_FORWARDED_HOST=False
+USE_X_FORWARDED_PORT=False
+SECURE_PROXY_SSL_HEADER_ENABLED=False
+SESSION_COOKIE_SECURE=False
+CSRF_COOKIE_SECURE=False
+SECURE_SSL_REDIRECT=False
+
+# Optional hostnames for the Caddy HTTPS layer in docker-compose.proxy.yml
+APP_DOMAIN=
+ONLYOFFICE_DOMAIN=
+ACME_EMAIL=
+
+# OnlyOffice Document Server
+# Set ONLYOFFICE_URL to the browser-reachable Document Server URL.
+# On a real server, prefer the server hostname or public IP instead of localhost.
+# ONLYOFFICE Docs Docker should be configured with environment variables rather
+# than manual edits to local.json. Use the same ONLYOFFICE_JWT_SECRET value in
+# both Django and the OnlyOffice container.
+# Set ONLYOFFICE_APP_BASE_URL when the document server must reach Django on a
+# different hostname than the browser uses. For local Docker Desktop testing,
+# this is usually http://host.docker.internal:8000.
+# Set ONLYOFFICE_INTERNAL_URL when Django must reach the document server on a
+# different hostname than the browser uses. For local Docker testing, this is
+# usually http://onlyoffice.
+ONLYOFFICE_URL=
+ONLYOFFICE_INTERNAL_URL=
+ONLYOFFICE_APP_BASE_URL=
+ONLYOFFICE_JWT_ENABLED=true
+ONLYOFFICE_JWT_SECRET=change-me
+ONLYOFFICE_CALLBACK_TIMEOUT=10
+
+# Optional extra URLs Django may trust when downloading saved files back from
+# Document Server. Comma-separated.
+ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=

--- a/.env.template
+++ b/.env.template
@@ -27,7 +27,8 @@ DB_PORT=5432
 ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal,web
 CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://host.docker.internal:8000
 
-# Set to True when the Django container should serve uploaded media itself.
+# Set to True only for isolated/internal pilot hosting. This serves uploaded
+# media directly from Django without per-file auth checks.
 SERVE_MEDIA=False
 
 # Email delivery

--- a/.env.template
+++ b/.env.template
@@ -24,7 +24,7 @@ DB_HOST=localhost
 DB_PORT=5432
 
 # Django host / origin config
-ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal
+ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal,web
 CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://host.docker.internal:8000
 
 # Set to True when the Django container should serve uploaded media itself.
@@ -66,8 +66,10 @@ ACME_EMAIL=
 # than manual edits to local.json. Use the same ONLYOFFICE_JWT_SECRET value in
 # both Django and the OnlyOffice container.
 # Set ONLYOFFICE_APP_BASE_URL when the document server must reach Django on a
-# different hostname than the browser uses. For local Docker Desktop testing,
-# this is usually http://host.docker.internal:8000.
+# different hostname than the browser uses. When Django is running in the same
+# Docker Compose stack, prefer the internal service URL http://web:8000.
+# Use http://host.docker.internal:8000 only if ONLYOFFICE is containerized but
+# Django is running directly on the host machine.
 # Set ONLYOFFICE_INTERNAL_URL when Django must reach the document server on a
 # different hostname than the browser uses. For local Docker testing, this is
 # usually http://onlyoffice.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 
 # Env files
 .env
+.env.local
+.env.docker
 .venv/
 venv/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        fonts-dejavu-core \
+        libcairo2 \
+        libffi-dev \
+        libgdk-pixbuf-2.0-0 \
+        libheif1 \
+        libjpeg62-turbo \
+        libopenjp2-7 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libpq-dev \
+        libwebp7 \
+        shared-mime-info \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip \
+    && pip install -r /app/requirements.txt
+
+COPY src /app/src
+COPY README.md /app/README.md
+COPY docs /app/docs
+COPY .env.template /app/.env.template
+COPY docker/entrypoint.sh /app/docker/entrypoint.sh
+
+RUN chmod +x /app/docker/entrypoint.sh \
+    && mkdir -p /app/src/media /app/src/staticfiles
+
+WORKDIR /app/src
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
+CMD ["gunicorn", "ce_portal.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3", "--timeout", "120"]

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ docker compose exec web python manage.py createsuperuser
 ```
 
 Detailed setup notes, including OnlyOffice URL/JWT configuration, are in [docs/docker.md](docs/docker.md).
-The admin-facing handoff checklist is in [docs/admin-handoff.md](docs/admin-handoff.md).
+The admin-facing handoff checklist is in [docs/instructions.md](docs/instructions.md).
 
 ## Repository Layout
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ python manage.py check
 python manage.py test
 ```
 
+## Docker Deployment
+
+A Docker-based deployment is now included for:
+- Django/Gunicorn
+- PostgreSQL
+- OnlyOffice Document Server
+
+Main files:
+- [Dockerfile](Dockerfile)
+- [docker-compose.yml](docker-compose.yml)
+- [docker/entrypoint.sh](docker/entrypoint.sh)
+
+Quick start:
+
+```bash
+cp .env.template .env
+docker compose up --build -d
+docker compose exec web python manage.py createsuperuser
+```
+
+Detailed setup notes, including OnlyOffice URL/JWT configuration, are in [docs/docker.md](docs/docker.md).
+The admin-facing handoff checklist is in [docs/admin-handoff.md](docs/admin-handoff.md).
+
 ## Repository Layout
 
 ```text

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Prerequisites:
 Setup:
 
 ```bash
-cp .env.template .env
+cp .env.local.template .env.local
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
@@ -142,7 +142,8 @@ python manage.py runserver
 Then open `http://127.0.0.1:8000/`.
 
 Notes:
-- database credentials are read from `.env`
+- direct Django commands automatically prefer `.env.local`, then fall back to `.env`
+- use `ENV_FILE=...` if you want to force a different env file for a specific command
 - the default database backend is PostgreSQL
 - email is configured to the console backend in development
 
@@ -153,6 +154,12 @@ source .venv/bin/activate
 cd src
 python manage.py check
 python manage.py test
+```
+
+Example override:
+
+```bash
+ENV_FILE=../.env.local python manage.py runserver
 ```
 
 ## Docker Deployment

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,0 +1,18 @@
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - web
+      - onlyoffice
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-ce_portal}
+      POSTGRES_USER: ${DB_USER:-ce_user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-ce_pass}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-ce_user} -d ${DB_NAME:-ce_portal}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      DEBUG: "False"
+      DB_HOST: db
+      DB_PORT: "5432"
+      SERVE_MEDIA: "True"
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,host.docker.internal}
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:8000,http://host.docker.internal:8000}
+      ONLYOFFICE_URL: ${ONLYOFFICE_URL:-}
+      ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET:-change-me}
+      ONLYOFFICE_CALLBACK_TIMEOUT: ${ONLYOFFICE_CALLBACK_TIMEOUT:-10}
+      ONLYOFFICE_TRUSTED_DOWNLOAD_URLS: ${ONLYOFFICE_TRUSTED_DOWNLOAD_URLS:-}
+    ports:
+      - "${WEB_BIND_HOST:-0.0.0.0}:${WEB_PORT:-8000}:8000"
+    volumes:
+      - media_data:/app/src/media
+
+  onlyoffice:
+    image: onlyoffice/documentserver:latest
+    restart: unless-stopped
+    environment:
+      JWT_ENABLED: ${ONLYOFFICE_JWT_ENABLED:-true}
+      JWT_SECRET: ${ONLYOFFICE_JWT_SECRET:-change-me}
+      JWT_HEADER: Authorization
+      JWT_IN_BODY: "true"
+    ports:
+      - "${ONLYOFFICE_BIND_HOST:-0.0.0.0}:${ONLYOFFICE_PORT:-8080}:80"
+    volumes:
+      - onlyoffice_data:/var/www/onlyoffice/Data
+
+volumes:
+  postgres_data:
+  media_data:
+  onlyoffice_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,8 @@ services:
       - media_data:/app/src/media
 
   onlyoffice:
-    image: onlyoffice/documentserver:latest
+    # Pin the validated Document Server version so pilot deployments stay reproducible.
+    image: onlyoffice/documentserver:9.0.4
     restart: unless-stopped
     environment:
       JWT_ENABLED: ${ONLYOFFICE_JWT_ENABLED:-true}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,13 @@
+{
+    email {$ACME_EMAIL}
+}
+
+{$APP_DOMAIN} {
+    encode gzip
+    reverse_proxy web:8000
+}
+
+{$ONLYOFFICE_DOMAIN} {
+    encode gzip
+    reverse_proxy onlyoffice:80
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+python - <<'PY'
+import os
+import time
+
+import psycopg
+
+host = os.getenv("DB_HOST", "db")
+port = int(os.getenv("DB_PORT", "5432"))
+dbname = os.getenv("DB_NAME", "")
+user = os.getenv("DB_USER", "")
+password = os.getenv("DB_PASSWORD", "")
+timeout = int(os.getenv("DB_WAIT_TIMEOUT", "60"))
+deadline = time.time() + timeout
+
+while True:
+    try:
+        conn = psycopg.connect(
+            host=host,
+            port=port,
+            dbname=dbname,
+            user=user,
+            password=password,
+            connect_timeout=5,
+        )
+        conn.close()
+        break
+    except Exception as exc:
+        if time.time() >= deadline:
+            raise SystemExit(
+                f"Database did not become ready within {timeout}s: {exc}"
+            )
+        time.sleep(2)
+PY
+
+python manage.py migrate --noinput
+python manage.py collectstatic --noinput
+
+exec "$@"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -64,20 +64,24 @@ The ONLYOFFICE setup works when these three URLs are set correctly:
 
 For the current Docker setup:
 - leave `ONLYOFFICE_INTERNAL_URL=http://onlyoffice`
+- if Django is also running in Docker Compose, set `ONLYOFFICE_APP_BASE_URL=http://web:8000`
 - keep the same `ONLYOFFICE_JWT_SECRET` in Django and ONLYOFFICE
 
 ## Local Docker Desktop Note
 
 For local Docker Desktop testing, the browser and the containers do not resolve `localhost` the same way.
 
-Typical local values are:
+Typical local values for the full Docker Compose stack are:
 
 ```env
 ONLYOFFICE_URL=http://localhost:8080
 ONLYOFFICE_INTERNAL_URL=http://onlyoffice
-ONLYOFFICE_APP_BASE_URL=http://host.docker.internal:8000
+ONLYOFFICE_APP_BASE_URL=http://web:8000
 ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=http://localhost:8080,http://onlyoffice
+ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal,web
 ```
+
+Use `http://host.docker.internal:8000` only if Django is running on the host machine and ONLYOFFICE is the only containerized part.
 
 ## Data Volumes
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,6 +39,9 @@ Copy the template:
 cp .env.template .env
 ```
 
+This Docker path continues to use `.env`. Direct non-Docker Django commands can
+use `.env.local` independently.
+
 Fill in at least:
 - `SECRET_KEY`
 - `DB_NAME`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -100,4 +100,5 @@ docker compose up --build -d
 
 - the container entrypoint runs migrations and collects static files automatically
 - uploaded media is served by Django in this Docker setup
+- `SERVE_MEDIA=True` is intended only for isolated/internal pilot deployments because media URLs are served directly without per-file auth checks
 - if a Docker Compose `SECRET_KEY` contains `$`, write it as `$$`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,235 @@
+# Docker Deployment
+
+This repo now includes a Docker-based runtime for:
+- the Django app
+- PostgreSQL
+- OnlyOffice Document Server
+
+The main files are:
+- [`Dockerfile`](../Dockerfile)
+- [`docker-compose.yml`](../docker-compose.yml)
+- [`docker-compose.proxy.yml`](../docker-compose.proxy.yml)
+- [`docker/entrypoint.sh`](../docker/entrypoint.sh)
+- [`docker/Caddyfile`](../docker/Caddyfile)
+
+## What The Containers Do
+
+- `web`: builds the Django app image, waits for PostgreSQL, runs migrations, collects static files, then starts Gunicorn on port `8000`
+- `db`: PostgreSQL database
+- `onlyoffice`: OnlyOffice Document Server on port `8080`
+
+## 1. Prepare The Server
+
+Install:
+- Docker Engine
+- Docker Compose plugin
+
+Clone the repo:
+
+```bash
+git clone <your-repo-url>
+cd CE-Synopsis-Portal
+```
+
+## 2. Create The Environment File
+
+Copy the template:
+
+```bash
+cp .env.template .env
+```
+
+Fill in at least:
+- `SECRET_KEY`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+- `ALLOWED_HOSTS`
+- `CSRF_TRUSTED_ORIGINS`
+- `DEFAULT_FROM_EMAIL`
+- `ONLYOFFICE_JWT_SECRET`
+
+Important:
+- if `SECRET_KEY` contains `$`, escape it as `$$` in the env file for Docker Compose
+- or generate a key without `$` characters
+
+## 3. Set The Public URLs Correctly
+
+For this app, OnlyOffice must be reachable from:
+- the browser
+- the Django container
+
+That means you should use a hostname or server IP that both can resolve.
+
+Example for a server at `203.0.113.10`:
+
+```env
+ALLOWED_HOSTS=203.0.113.10,localhost,127.0.0.1
+CSRF_TRUSTED_ORIGINS=http://203.0.113.10:8000
+ONLYOFFICE_URL=http://203.0.113.10:8080
+ONLYOFFICE_INTERNAL_URL=http://onlyoffice
+ONLYOFFICE_APP_BASE_URL=http://203.0.113.10:8000
+ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=http://203.0.113.10:8080,http://onlyoffice
+```
+
+If you later put the stack behind HTTPS and a reverse proxy, update these to the final HTTPS URLs.
+
+For local Docker Desktop testing, the browser and the OnlyOffice container do
+not resolve `localhost` the same way. Keep `ONLYOFFICE_URL=http://localhost:8080`
+for the browser, and set:
+
+```env
+ONLYOFFICE_INTERNAL_URL=http://onlyoffice
+ONLYOFFICE_APP_BASE_URL=http://host.docker.internal:8000
+```
+
+That makes:
+- Django -> OnlyOffice use the Docker service hostname
+- OnlyOffice -> Django use the Docker host bridge
+
+## 3a. Configure ONLYOFFICE JWT The Docker Way
+
+The official ONLYOFFICE Docs guidance for Docker is:
+- use environment variables, not manual edits to `local.json`
+- set `JWT_ENABLED=true`
+- set `JWT_SECRET` to your chosen shared secret
+
+This repo already follows that approach:
+- `.env` uses `ONLYOFFICE_JWT_SECRET`
+- `docker-compose.yml` passes that to the `onlyoffice` container as `JWT_SECRET`
+- Django reads the same `.env` value as `ONLYOFFICE_JWT_SECRET`
+
+Important:
+- the Django app and the `onlyoffice` container must use the same secret
+- if you disable JWT for troubleshooting, set `ONLYOFFICE_JWT_ENABLED=False` in `.env`
+- for a real hosted environment, leave JWT enabled
+
+Example:
+
+```env
+ONLYOFFICE_JWT_ENABLED=true
+ONLYOFFICE_JWT_SECRET=replace-this-with-a-long-random-secret
+```
+
+## 3b. If You Put Django Behind HTTPS Later
+
+When you add Nginx or Caddy in front of Django, also set these in `.env`:
+
+```env
+USE_X_FORWARDED_HOST=True
+USE_X_FORWARDED_PORT=True
+SECURE_PROXY_SSL_HEADER_ENABLED=True
+SESSION_COOKIE_SECURE=True
+CSRF_COOKIE_SECURE=True
+SECURE_SSL_REDIRECT=True
+```
+
+Do not turn those on while serving Django directly over plain HTTP, or login
+cookies and redirects will behave incorrectly.
+
+## 4. Start The Stack
+
+```bash
+docker compose up --build -d
+```
+
+This will:
+- build the Django image
+- start PostgreSQL
+- run migrations automatically
+- collect static files automatically
+- start Gunicorn
+- start OnlyOffice
+
+## 4a. Recommended Online Pilot: Use The Caddy HTTPS Layer
+
+For a team-accessible online pilot, prefer:
+- one hostname for Django, for example `synopsis.example.org`
+- one hostname for OnlyOffice, for example `docs.example.org`
+- HTTPS terminated by Caddy
+
+In `.env`, set:
+
+```env
+APP_DOMAIN=synopsis.example.org
+ONLYOFFICE_DOMAIN=docs.example.org
+ACME_EMAIL=admin@example.org
+WEB_BIND_HOST=127.0.0.1
+ONLYOFFICE_BIND_HOST=127.0.0.1
+ALLOWED_HOSTS=synopsis.example.org
+CSRF_TRUSTED_ORIGINS=https://synopsis.example.org
+ONLYOFFICE_URL=https://docs.example.org
+ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=https://docs.example.org,http://onlyoffice
+USE_X_FORWARDED_HOST=True
+USE_X_FORWARDED_PORT=True
+SECURE_PROXY_SSL_HEADER_ENABLED=True
+SESSION_COOKIE_SECURE=True
+CSRF_COOKIE_SECURE=True
+SECURE_SSL_REDIRECT=True
+```
+
+Then start the full stack with:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml up --build -d
+```
+
+Caddy will proxy:
+- `APP_DOMAIN` -> Django/Gunicorn
+- `ONLYOFFICE_DOMAIN` -> OnlyOffice Document Server
+
+## 5. Create An Admin User
+
+```bash
+docker compose exec web python manage.py createsuperuser
+```
+
+## 6. Open The Services
+
+- App: `http://<server-host>:8000`
+- OnlyOffice: `http://<server-host>:8080`
+
+If using the optional Caddy layer instead:
+- App: `https://<APP_DOMAIN>`
+- OnlyOffice: `https://<ONLYOFFICE_DOMAIN>`
+
+If you switch email delivery away from the console backend for the hosted pilot,
+set the SMTP-related environment variables in `.env` as well:
+
+```env
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_HOST_USER=your-user
+EMAIL_HOST_PASSWORD=your-password
+EMAIL_USE_TLS=True
+DEFAULT_FROM_EMAIL=CE Synopsis Portal <noreply@example.com>
+SERVER_EMAIL=CE Synopsis Portal <noreply@example.com>
+```
+
+## 7. Updating The App Later
+
+```bash
+git pull
+docker compose up --build -d
+```
+
+## Notes
+
+- Uploaded files are stored in the `media_data` Docker volume.
+- PostgreSQL data is stored in the `postgres_data` Docker volume.
+- OnlyOffice data is stored in the `onlyoffice_data` Docker volume.
+- The app serves uploaded media itself in this container setup (`SERVE_MEDIA=True` in compose).
+- Static files are collected and served by WhiteNoise inside the Django container.
+
+## Operational Recommendation
+
+For the online server, the cleanest next step after this is:
+- keep Docker Compose for the app stack
+- place Nginx or Caddy in front of it
+- terminate HTTPS there
+- point a real hostname at the server
+
+That is not required for the basic stack to run, but it is the right direction for a more durable deployment.
+
+See also [`admin-handoff.md`](admin-handoff.md) for the ownership split and the checklist you can send directly to admins.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,216 +1,91 @@
-# Docker Deployment
+# Docker Notes
 
-This repo now includes a Docker-based runtime for:
-- the Django app
-- PostgreSQL
-- OnlyOffice Document Server
+This is a short technical reference for the Docker runtime in this repo.
 
-The main files are:
+If you are deploying the pilot on a server, use [`admin-handoff.md`](admin-handoff.md) first. This file is just background on how the Docker setup is wired.
+
+## Files
+
 - [`Dockerfile`](../Dockerfile)
 - [`docker-compose.yml`](../docker-compose.yml)
 - [`docker-compose.proxy.yml`](../docker-compose.proxy.yml)
 - [`docker/entrypoint.sh`](../docker/entrypoint.sh)
 - [`docker/Caddyfile`](../docker/Caddyfile)
 
-## What The Containers Do
+## Services
 
-- `web`: builds the Django app image, waits for PostgreSQL, runs migrations, collects static files, then starts Gunicorn on port `8000`
-- `db`: PostgreSQL database
-- `onlyoffice`: OnlyOffice Document Server on port `8080`
+- `web`: Django app behind Gunicorn on port `8000`
+- `db`: PostgreSQL
+- `onlyoffice`: ONLYOFFICE Document Server on port `8080`
 
-## 1. Prepare The Server
+Optional:
+- `caddy`: reverse proxy and HTTPS when using `docker-compose.proxy.yml`
 
-Install:
-- Docker Engine
-- Docker Compose plugin
-
-Clone the repo:
-
-```bash
-git clone <your-repo-url>
-cd CE-Synopsis-Portal
-```
-
-## 2. Create The Environment File
-
-Copy the template:
+## Basic Run
 
 ```bash
 cp .env.template .env
+docker compose up --build -d
+docker compose exec web python manage.py createsuperuser
 ```
 
-This Docker path continues to use `.env`. Direct non-Docker Django commands can
-use `.env.local` independently.
+## Key Environment Variables
 
-Fill in at least:
+Most of the Docker-specific setup comes down to these:
+
 - `SECRET_KEY`
 - `DB_NAME`
 - `DB_USER`
 - `DB_PASSWORD`
 - `ALLOWED_HOSTS`
 - `CSRF_TRUSTED_ORIGINS`
-- `DEFAULT_FROM_EMAIL`
+- `ONLYOFFICE_URL`
+- `ONLYOFFICE_INTERNAL_URL`
+- `ONLYOFFICE_APP_BASE_URL`
 - `ONLYOFFICE_JWT_SECRET`
+- `ONLYOFFICE_TRUSTED_DOWNLOAD_URLS`
 
-Important:
-- if `SECRET_KEY` contains `$`, escape it as `$$` in the env file for Docker Compose
-- or generate a key without `$` characters
+Email for pilot testing:
+- `EMAIL_BACKEND`
+- `EMAIL_HOST`
+- `EMAIL_PORT`
+- `EMAIL_HOST_USER`
+- `EMAIL_HOST_PASSWORD`
+- `EMAIL_USE_TLS`
+- `DEFAULT_FROM_EMAIL`
 
-## 3. Set The Public URLs Correctly
+## ONLYOFFICE URL Rules
 
-For this app, OnlyOffice must be reachable from:
-- the browser
-- the Django container
+The ONLYOFFICE setup works when these three URLs are set correctly:
 
-That means you should use a hostname or server IP that both can resolve.
+- `ONLYOFFICE_URL`: what the browser opens
+- `ONLYOFFICE_INTERNAL_URL`: how Django reaches ONLYOFFICE inside Docker
+- `ONLYOFFICE_APP_BASE_URL`: how ONLYOFFICE reaches Django for downloads and save callbacks
 
-Example for a server at `203.0.113.10`:
+For the current Docker setup:
+- leave `ONLYOFFICE_INTERNAL_URL=http://onlyoffice`
+- keep the same `ONLYOFFICE_JWT_SECRET` in Django and ONLYOFFICE
+
+## Local Docker Desktop Note
+
+For local Docker Desktop testing, the browser and the containers do not resolve `localhost` the same way.
+
+Typical local values are:
 
 ```env
-ALLOWED_HOSTS=203.0.113.10,localhost,127.0.0.1
-CSRF_TRUSTED_ORIGINS=http://203.0.113.10:8000
-ONLYOFFICE_URL=http://203.0.113.10:8080
-ONLYOFFICE_INTERNAL_URL=http://onlyoffice
-ONLYOFFICE_APP_BASE_URL=http://203.0.113.10:8000
-ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=http://203.0.113.10:8080,http://onlyoffice
-```
-
-If you later put the stack behind HTTPS and a reverse proxy, update these to the final HTTPS URLs.
-
-For local Docker Desktop testing, the browser and the OnlyOffice container do
-not resolve `localhost` the same way. Keep `ONLYOFFICE_URL=http://localhost:8080`
-for the browser, and set:
-
-```env
+ONLYOFFICE_URL=http://localhost:8080
 ONLYOFFICE_INTERNAL_URL=http://onlyoffice
 ONLYOFFICE_APP_BASE_URL=http://host.docker.internal:8000
+ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=http://localhost:8080,http://onlyoffice
 ```
 
-That makes:
-- Django -> OnlyOffice use the Docker service hostname
-- OnlyOffice -> Django use the Docker host bridge
+## Data Volumes
 
-## 3a. Configure ONLYOFFICE JWT The Docker Way
+- PostgreSQL data: `postgres_data`
+- uploaded media and saved revisions: `media_data`
+- ONLYOFFICE data: `onlyoffice_data`
 
-The official ONLYOFFICE Docs guidance for Docker is:
-- use environment variables, not manual edits to `local.json`
-- set `JWT_ENABLED=true`
-- set `JWT_SECRET` to your chosen shared secret
-
-This repo already follows that approach:
-- `.env` uses `ONLYOFFICE_JWT_SECRET`
-- `docker-compose.yml` passes that to the `onlyoffice` container as `JWT_SECRET`
-- Django reads the same `.env` value as `ONLYOFFICE_JWT_SECRET`
-
-Important:
-- the Django app and the `onlyoffice` container must use the same secret
-- if you disable JWT for troubleshooting, set `ONLYOFFICE_JWT_ENABLED=False` in `.env`
-- for a real hosted environment, leave JWT enabled
-
-Example:
-
-```env
-ONLYOFFICE_JWT_ENABLED=true
-ONLYOFFICE_JWT_SECRET=replace-this-with-a-long-random-secret
-```
-
-## 3b. If You Put Django Behind HTTPS Later
-
-When you add Nginx or Caddy in front of Django, also set these in `.env`:
-
-```env
-USE_X_FORWARDED_HOST=True
-USE_X_FORWARDED_PORT=True
-SECURE_PROXY_SSL_HEADER_ENABLED=True
-SESSION_COOKIE_SECURE=True
-CSRF_COOKIE_SECURE=True
-SECURE_SSL_REDIRECT=True
-```
-
-Do not turn those on while serving Django directly over plain HTTP, or login
-cookies and redirects will behave incorrectly.
-
-## 4. Start The Stack
-
-```bash
-docker compose up --build -d
-```
-
-This will:
-- build the Django image
-- start PostgreSQL
-- run migrations automatically
-- collect static files automatically
-- start Gunicorn
-- start OnlyOffice
-
-## 4a. Recommended Online Pilot: Use The Caddy HTTPS Layer
-
-For a team-accessible online pilot, prefer:
-- one hostname for Django, for example `synopsis.example.org`
-- one hostname for OnlyOffice, for example `docs.example.org`
-- HTTPS terminated by Caddy
-
-In `.env`, set:
-
-```env
-APP_DOMAIN=synopsis.example.org
-ONLYOFFICE_DOMAIN=docs.example.org
-ACME_EMAIL=admin@example.org
-WEB_BIND_HOST=127.0.0.1
-ONLYOFFICE_BIND_HOST=127.0.0.1
-ALLOWED_HOSTS=synopsis.example.org
-CSRF_TRUSTED_ORIGINS=https://synopsis.example.org
-ONLYOFFICE_URL=https://docs.example.org
-ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=https://docs.example.org,http://onlyoffice
-USE_X_FORWARDED_HOST=True
-USE_X_FORWARDED_PORT=True
-SECURE_PROXY_SSL_HEADER_ENABLED=True
-SESSION_COOKIE_SECURE=True
-CSRF_COOKIE_SECURE=True
-SECURE_SSL_REDIRECT=True
-```
-
-Then start the full stack with:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.proxy.yml up --build -d
-```
-
-Caddy will proxy:
-- `APP_DOMAIN` -> Django/Gunicorn
-- `ONLYOFFICE_DOMAIN` -> OnlyOffice Document Server
-
-## 5. Create An Admin User
-
-```bash
-docker compose exec web python manage.py createsuperuser
-```
-
-## 6. Open The Services
-
-- App: `http://<server-host>:8000`
-- OnlyOffice: `http://<server-host>:8080`
-
-If using the optional Caddy layer instead:
-- App: `https://<APP_DOMAIN>`
-- OnlyOffice: `https://<ONLYOFFICE_DOMAIN>`
-
-If you switch email delivery away from the console backend for the hosted pilot,
-set the SMTP-related environment variables in `.env` as well:
-
-```env
-EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
-EMAIL_HOST=smtp.example.com
-EMAIL_PORT=587
-EMAIL_HOST_USER=your-user
-EMAIL_HOST_PASSWORD=your-password
-EMAIL_USE_TLS=True
-DEFAULT_FROM_EMAIL=CE Synopsis Portal <noreply@example.com>
-SERVER_EMAIL=CE Synopsis Portal <noreply@example.com>
-```
-
-## 7. Updating The App Later
+## Updating
 
 ```bash
 git pull
@@ -219,20 +94,6 @@ docker compose up --build -d
 
 ## Notes
 
-- Uploaded files are stored in the `media_data` Docker volume.
-- PostgreSQL data is stored in the `postgres_data` Docker volume.
-- OnlyOffice data is stored in the `onlyoffice_data` Docker volume.
-- The app serves uploaded media itself in this container setup (`SERVE_MEDIA=True` in compose).
-- Static files are collected and served by WhiteNoise inside the Django container.
-
-## Operational Recommendation
-
-For the online server, the cleanest next step after this is:
-- keep Docker Compose for the app stack
-- place Nginx or Caddy in front of it
-- terminate HTTPS there
-- point a real hostname at the server
-
-That is not required for the basic stack to run, but it is the right direction for a more durable deployment.
-
-See also [`admin-handoff.md`](admin-handoff.md) for the ownership split and the checklist you can send directly to admins.
+- the container entrypoint runs migrations and collects static files automatically
+- uploaded media is served by Django in this Docker setup
+- if a Docker Compose `SECRET_KEY` contains `$`, write it as `$$`

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -70,7 +70,7 @@ SECURE_SSL_REDIRECT=False
 ```
 
 Notes to clarify thinsgs:
-- `ONLYOFFICE_URL` is the ber-facing ONLYOFFICE URL.
+- `ONLYOFFICE_URL` is the browser-facing ONLYOFFICE URL.
 - `ONLYOFFICE_INTERNAL_URL` should stay `http://onlyoffice` in Docker.
 - `ONLYOFFICE_APP_BASE_URL` is the app URL ONLYOFFICE uses to fetch documents and send save callbacks.
 - `ONLYOFFICE_JWT_SECRET` must match between Django and ONLYOFFICE.

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,0 +1,92 @@
+## Pilot Setup
+
+Public URLs:
+- app: `http://<server-ip>:8000`
+- ONLYOFFICE: `http://<server-ip>:8080`
+
+For this simple onine pilot, email should send only to internal test inboxes.
+
+## Values needed
+
+Admin to provide:
+- server IP
+- Django `SECRET_KEY`
+- PostgreSQL password
+- ONLYOFFICE JWT secret
+- SMTP host
+- SMTP port
+- SMTP user
+- SMTP password
+- sender mailbox for the pilot
+
+## `.env` configuration
+
+Start from:
+
+```bash
+cp .env.template .env
+```
+
+Set at least:
+
+```env
+SECRET_KEY=<django-secret>
+
+DB_NAME=ce_portal
+DB_USER=ce_user
+DB_PASSWORD=<db-password>
+
+WEB_BIND_HOST=0.0.0.0
+WEB_PORT=8000
+ONLYOFFICE_BIND_HOST=0.0.0.0
+ONLYOFFICE_PORT=8080
+
+ALLOWED_HOSTS=<server-ip>
+CSRF_TRUSTED_ORIGINS=http://<server-ip>:8000
+
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=<smtp-host>
+EMAIL_PORT=587
+EMAIL_HOST_USER=<smtp-user>
+EMAIL_HOST_PASSWORD=<smtp-password>
+EMAIL_USE_TLS=True
+EMAIL_USE_SSL=False
+DEFAULT_FROM_EMAIL=CE Synopsis Pilot <pilot-mailbox@your-organisation>
+SERVER_EMAIL=CE Synopsis Pilot <pilot-mailbox@your-organisation>
+
+ONLYOFFICE_URL=http://<server-ip>:8080
+ONLYOFFICE_INTERNAL_URL=http://onlyoffice
+ONLYOFFICE_APP_BASE_URL=http://<server-ip>:8000
+ONLYOFFICE_JWT_ENABLED=true
+ONLYOFFICE_JWT_SECRET=<onlyoffice-jwt-secret>
+ONLYOFFICE_TRUSTED_DOWNLOAD_URLS=http://<server-ip>:8080,http://onlyoffice
+
+USE_X_FORWARDED_HOST=False
+USE_X_FORWARDED_PORT=False
+SECURE_PROXY_SSL_HEADER_ENABLED=False
+SESSION_COOKIE_SECURE=False
+CSRF_COOKIE_SECURE=False
+SECURE_SSL_REDIRECT=False
+```
+
+Notes to clarify thinsgs:
+- `ONLYOFFICE_URL` is the ber-facing ONLYOFFICE URL.
+- `ONLYOFFICE_INTERNAL_URL` should stay `http://onlyoffice` in Docker.
+- `ONLYOFFICE_APP_BASE_URL` is the app URL ONLYOFFICE uses to fetch documents and send save callbacks.
+- `ONLYOFFICE_JWT_SECRET` must match between Django and ONLYOFFICE.
+- If `SECRET_KEY` contains `$`, write it as `$$` in `.env`.
+
+## Deploy
+
+From the server:
+
+```bash
+git clone <repo-url>
+cd CE-Synopsis-Por
+cp .env.template .env
+# fill .env
+docker compose up --build -d
+docker compose exec web python manage.py createsuperuser
+```
+
+Create a superuser account for Ibrahim after deployment and send details aftewards.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ djangorestframework==3.16.1
 et_xmlfile==2.0.0
 filetype==1.2.0
 fonttools==4.59.2
+gunicorn==23.0.0
 rispy==0.10.0
 idna==3.10
 iniconfig==2.1.0
@@ -62,5 +63,6 @@ vine==5.1.0
 wcwidth==0.2.13
 weasyprint==66.0
 webencodings==0.5.1
+whitenoise==6.8.2
 zopfli==0.2.3.post1
 python-docx

--- a/src/ce_portal/settings.py
+++ b/src/ce_portal/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import importlib.util
 import os
 from pathlib import Path
-from decouple import AutoConfig, Config, RepositoryEnv
+from decouple import AutoConfig, Config, RepositoryEnv, UndefinedValueError, strtobool
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -48,6 +48,45 @@ def _csv_config(name: str, default: str = "") -> list[str]:
     return [item.strip() for item in raw_value.split(",") if item.strip()]
 
 
+def _repository_value(name: str) -> str | None:
+    repository = getattr(config, "repository", None)
+    if repository is None:
+        return None
+    try:
+        return repository[name]
+    except KeyError:
+        return None
+
+
+def _bool_from_string(value: str) -> bool:
+    value = (value or "").strip()
+    return bool(value) if value == "" else bool(strtobool(value))
+
+
+def _bool_config(name: str, default: bool = False, fallback_names: tuple[str, ...] = ()) -> bool:
+    for env_name in (name, *fallback_names):
+        raw_env = os.environ.get(env_name)
+        if raw_env is None:
+            continue
+        try:
+            return _bool_from_string(raw_env)
+        except ValueError:
+            # Ignore unrelated shell values like DEBUG=release and fall back to
+            # the project env file instead of breaking manage.py commands.
+            continue
+
+    for env_name in (name, *fallback_names):
+        raw_repo = _repository_value(env_name)
+        if raw_repo is None:
+            continue
+        return _bool_from_string(raw_repo)
+
+    try:
+        return config(name, cast=bool, default=default)
+    except (UndefinedValueError, ValueError):
+        return default
+
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
@@ -55,7 +94,7 @@ def _csv_config(name: str, default: str = "") -> list[str]:
 SECRET_KEY = config("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config("DEBUG", cast=bool, default=False)
+DEBUG = _bool_config("DJANGO_DEBUG", default=False, fallback_names=("DEBUG",))
 
 ALLOWED_HOSTS = _csv_config(
     "ALLOWED_HOSTS",

--- a/src/ce_portal/settings.py
+++ b/src/ce_portal/settings.py
@@ -10,11 +10,20 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import importlib.util
 from pathlib import Path
 from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+HAS_WHITENOISE = importlib.util.find_spec("whitenoise") is not None
+
+
+def _csv_config(name: str, default: str = "") -> list[str]:
+    raw_value = config(name, default=default)
+    if not raw_value:
+        return []
+    return [item.strip() for item in raw_value.split(",") if item.strip()]
 
 
 # Quick-start development settings - unsuitable for production
@@ -26,7 +35,10 @@ SECRET_KEY = config("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config("DEBUG", cast=bool, default=False)
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "host.docker.internal"]
+ALLOWED_HOSTS = _csv_config(
+    "ALLOWED_HOSTS",
+    default="localhost,127.0.0.1,host.docker.internal",
+)
 
 
 # Application definition
@@ -51,6 +63,9 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+if HAS_WHITENOISE:
+    MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
 
 ROOT_URLCONF = "ce_portal.urls"
 
@@ -121,7 +136,21 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": (
+            "whitenoise.storage.CompressedManifestStaticFilesStorage"
+            if HAS_WHITENOISE
+            else "django.contrib.staticfiles.storage.StaticFilesStorage"
+        ),
+    },
+}
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
@@ -134,10 +163,35 @@ LOGIN_URL = "/login/"
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
+SERVE_MEDIA = config("SERVE_MEDIA", cast=bool, default=False)
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-# TODO: IMPORTANT!Change this in post-production to a real email address.
-DEFAULT_FROM_EMAIL = "CE Synopsis Portal <ce-portal@localhost>"
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND",
+    default="django.core.mail.backends.console.EmailBackend",
+)
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config("EMAIL_PORT", cast=int, default=25)
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", cast=bool, default=False)
+EMAIL_USE_SSL = config("EMAIL_USE_SSL", cast=bool, default=False)
+EMAIL_TIMEOUT = config("EMAIL_TIMEOUT", cast=int, default=10)
+DEFAULT_FROM_EMAIL = config(
+    "DEFAULT_FROM_EMAIL",
+    default="CE Synopsis Portal <ce-portal@localhost>",
+)
+SERVER_EMAIL = config("SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
+
+USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", cast=bool, default=False)
+USE_X_FORWARDED_PORT = config("USE_X_FORWARDED_PORT", cast=bool, default=False)
+SECURE_PROXY_SSL_HEADER = (
+    ("HTTP_X_FORWARDED_PROTO", "https")
+    if config("SECURE_PROXY_SSL_HEADER_ENABLED", cast=bool, default=False)
+    else None
+)
+SESSION_COOKIE_SECURE = config("SESSION_COOKIE_SECURE", cast=bool, default=False)
+CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", cast=bool, default=False)
+SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", cast=bool, default=False)
 
 # Advisory board response windows
 ADVISORY_INVITE_RESPONSE_WINDOW_DAYS = 10
@@ -147,13 +201,15 @@ ADVISORY_REMINDER_LEAD_BUSINESS_DAYS = 2
 
 # OnlyOffice Document Server configuration (collaborative editing)
 ONLYOFFICE = {
-    "base_url": config("ONLYOFFICE_URL", default="http://localhost"),
+    "base_url": config("ONLYOFFICE_URL", default=""),
+    "internal_url": config("ONLYOFFICE_INTERNAL_URL", default=""),
+    "app_base_url": config("ONLYOFFICE_APP_BASE_URL", default=""),
     "jwt_secret": config("ONLYOFFICE_JWT_SECRET", default="change-me"),
     "callback_timeout": config("ONLYOFFICE_CALLBACK_TIMEOUT", cast=int, default=10),
+    "trusted_download_urls": _csv_config("ONLYOFFICE_TRUSTED_DOWNLOAD_URLS"),
 }
 
-CSRF_TRUSTED_ORIGINS = [
-    "http://localhost:8000",
-    "http://host.docker.internal:8000",
-]
-# TODO: get django settings and onlyoffice injection ready for the online pilot (for docker compose too).
+CSRF_TRUSTED_ORIGINS = _csv_config(
+    "CSRF_TRUSTED_ORIGINS",
+    default="http://localhost:8000,http://host.docker.internal:8000",
+)

--- a/src/ce_portal/settings.py
+++ b/src/ce_portal/settings.py
@@ -11,12 +11,34 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 import importlib.util
+import os
 from pathlib import Path
-from decouple import config
+from decouple import AutoConfig, Config, RepositoryEnv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = BASE_DIR.parent
 HAS_WHITENOISE = importlib.util.find_spec("whitenoise") is not None
+
+
+def _build_config():
+    env_file_override = (os.environ.get("ENV_FILE") or "").strip()
+    if env_file_override:
+        env_path = Path(env_file_override)
+        if not env_path.is_absolute():
+            env_path = REPO_ROOT / env_path
+        if not env_path.exists():
+            raise FileNotFoundError(f"Configured ENV_FILE does not exist: {env_path}")
+        return Config(RepositoryEnv(str(env_path))), env_path
+
+    for candidate in (REPO_ROOT / ".env.local", REPO_ROOT / ".env"):
+        if candidate.exists():
+            return Config(RepositoryEnv(str(candidate))), candidate
+
+    return AutoConfig(search_path=str(REPO_ROOT)), None
+
+
+config, ACTIVE_ENV_FILE = _build_config()
 
 
 def _csv_config(name: str, default: str = "") -> list[str]:

--- a/src/ce_portal/settings.py
+++ b/src/ce_portal/settings.py
@@ -199,6 +199,7 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
+USE_MANIFEST_STATIC_STORAGE = HAS_WHITENOISE and not DEBUG
 
 STORAGES = {
     "default": {
@@ -207,7 +208,7 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": (
             "whitenoise.storage.CompressedManifestStaticFilesStorage"
-            if HAS_WHITENOISE
+            if USE_MANIFEST_STATIC_STORAGE
             else "django.contrib.staticfiles.storage.StaticFilesStorage"
         ),
     },

--- a/src/ce_portal/urls.py
+++ b/src/ce_portal/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 elif getattr(settings, "SERVE_MEDIA", False):
+    # Internal pilot only: this exposes MEDIA_URL directly without per-file auth.
     media_prefix = settings.MEDIA_URL.lstrip("/")
     urlpatterns += [
         re_path(

--- a/src/ce_portal/urls.py
+++ b/src/ce_portal/urls.py
@@ -16,14 +16,25 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.static import serve
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     # path("accounts/", include("django.contrib.auth.urls")), TODO: research if using this is better.
     path("", include("synopsis.urls", namespace="synopsis")),
 ]
+
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+elif getattr(settings, "SERVE_MEDIA", False):
+    media_prefix = settings.MEDIA_URL.lstrip("/")
+    urlpatterns += [
+        re_path(
+            rf"^{media_prefix}(?P<path>.*)$",
+            serve,
+            {"document_root": settings.MEDIA_ROOT},
+        )
+    ]

--- a/src/synopsis/apps.py
+++ b/src/synopsis/apps.py
@@ -6,11 +6,4 @@ class SynopsisConfig(AppConfig):
     name = "synopsis"
 
     def ready(self):
-        # Ensure default groups exist at startup
-        try:
-            from .utils import ensure_global_groups
-
-            ensure_global_groups()
-        except Exception:
-            # During migrations / checks, DB might not be ready; ignore
-            pass
+        from . import signals  # noqa: F401

--- a/src/synopsis/signals.py
+++ b/src/synopsis/signals.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from django.db.models.signals import post_migrate
 from django.dispatch import receiver
 
@@ -8,8 +7,5 @@ from .utils import ensure_global_groups
 @receiver(post_migrate)
 def synopsis_post_migrate(sender, app_config, **kwargs):
     if app_config.name != "synopsis":
-        return
-    auth_group = apps.get_model("auth", "Group")
-    if auth_group is None:
         return
     ensure_global_groups()

--- a/src/synopsis/signals.py
+++ b/src/synopsis/signals.py
@@ -1,0 +1,15 @@
+from django.apps import apps
+from django.db.models.signals import post_migrate
+from django.dispatch import receiver
+
+from .utils import ensure_global_groups
+
+
+@receiver(post_migrate)
+def synopsis_post_migrate(sender, app_config, **kwargs):
+    if app_config.name != "synopsis":
+        return
+    auth_group = apps.get_model("auth", "Group")
+    if auth_group is None:
+        return
+    ensure_global_groups()

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -2541,7 +2541,7 @@ class OnlyOfficeConfigTests(TestCase):
         views.ONLYOFFICE_SETTINGS = {
             "base_url": "http://localhost:8080",
             "internal_url": "http://onlyoffice",
-            "app_base_url": "http://host.docker.internal:8000",
+            "app_base_url": "http://web:8000",
             "jwt_secret": "change-me",
             "callback_timeout": 10,
             "trusted_download_urls": [
@@ -2591,13 +2591,20 @@ class OnlyOfficeConfigTests(TestCase):
             CollaborativeSession.DOCUMENT_PROTOCOL,
         )
 
-        self.assertTrue(
-            config["document"]["url"].startswith("http://host.docker.internal:8000/")
-        )
-        self.assertTrue(
-            config["editorConfig"]["callbackUrl"].startswith(
-                "http://host.docker.internal:8000/"
-            )
+        document_url = urlparse(config["document"]["url"])
+        callback_url = urlparse(config["editorConfig"]["callbackUrl"])
+
+        self.assertEqual(document_url.scheme, "http")
+        self.assertEqual(document_url.netloc, "web:8000")
+        self.assertTrue(document_url.path.startswith("/media/"))
+        self.assertEqual(callback_url.scheme, "http")
+        self.assertEqual(callback_url.netloc, "web:8000")
+        self.assertEqual(
+            callback_url.path,
+            reverse(
+                "synopsis:collaborative_edit_callback",
+                args=[self.project.id, "protocol", self.session.token],
+            ),
         )
 
 

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -2627,7 +2627,7 @@ class CollaborativeForceSaveCloseTests(TestCase):
     @patch("synopsis.views._wait_for_collaborative_save", return_value=False)
     @patch(
         "synopsis.views._request_onlyoffice_forcesave",
-        return_value=(False, "Unable to request a final save from OnlyOffice."),
+        return_value=("failed", "Unable to request a final save from OnlyOffice."),
     )
     def test_force_end_keeps_session_open_when_save_request_fails(
         self, mock_request, mock_wait
@@ -2651,7 +2651,7 @@ class CollaborativeForceSaveCloseTests(TestCase):
     @patch("synopsis.views._wait_for_collaborative_save", return_value=True)
     @patch(
         "synopsis.views._request_onlyoffice_forcesave",
-        return_value=(True, "Final save requested from OnlyOffice."),
+        return_value=("requested", "Final save requested from OnlyOffice."),
     )
     def test_force_end_reports_success_after_final_save(
         self, mock_request, mock_wait
@@ -2669,6 +2669,30 @@ class CollaborativeForceSaveCloseTests(TestCase):
         )
         mock_request.assert_called_once()
         mock_wait.assert_called_once()
+
+    @patch("synopsis.views._wait_for_collaborative_save")
+    @patch(
+        "synopsis.views._request_onlyoffice_forcesave",
+        return_value=("noop", "No unsaved changes were pending in OnlyOffice."),
+    )
+    def test_force_end_closes_session_when_no_unsaved_changes(
+        self, mock_request, mock_wait
+    ):
+        response = self.client.post(self.url, {"reason": "Close from portal"})
+
+        self.assertRedirects(
+            response,
+            reverse("synopsis:protocol_detail", args=[self.project.id]),
+        )
+        self.session.refresh_from_db()
+        self.assertFalse(self.session.is_active)
+        messages_list = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertIn(
+            "Protocol had no unsaved changes and the session was closed.",
+            messages_list,
+        )
+        mock_request.assert_called_once()
+        mock_wait.assert_not_called()
 
 
 class MediaServingUrlTests(SimpleTestCase):

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -2693,6 +2693,9 @@ class CollaborativeForceSaveCloseTests(TestCase):
         )
         self.session.refresh_from_db()
         self.assertFalse(self.session.is_active)
+        self.assertEqual(self.session.ended_by, self.manager)
+        self.assertEqual(self.session.end_reason, "Close from portal")
+        self.assertEqual(self.session.change_summary, "Close from portal")
         messages_list = [message.message for message in get_messages(response.wsgi_request)]
         self.assertIn(
             "Protocol had no unsaved changes and the session was closed.",

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -1,13 +1,16 @@
 from datetime import date, datetime, timedelta
+import importlib
 import io
+import json
 from urllib.parse import urlparse
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
+import jwt
 from django.contrib.auth.models import Group, User, AnonymousUser
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase, override_settings, RequestFactory
+from django.test import TestCase, override_settings, RequestFactory, SimpleTestCase
 from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -78,6 +81,9 @@ from .utils import (
 from .views import (
     _advisory_board_context,
     _build_advisory_invitation_email,
+    _build_onlyoffice_config,
+    _download_onlyoffice_file,
+    _parse_onlyoffice_callback,
     _create_protocol_feedback,
     _format_deadline,
     _format_value,
@@ -2300,6 +2306,68 @@ class OnlyOfficeDownloadTests(TestCase):
             self.views._download_onlyoffice_file(url)
         mock_get.assert_not_called()
 
+    @patch("synopsis.views.requests.get")
+    def test_download_uses_internal_onlyoffice_url_when_base_is_browser_host(self, mock_get):
+        self.views.ONLYOFFICE_SETTINGS = {
+            "base_url": "http://localhost:8080",
+            "internal_url": "http://onlyoffice",
+            "callback_timeout": 7,
+            "trusted_download_urls": ["http://onlyoffice"],
+        }
+        mock_response = MagicMock()
+        mock_response.content = b"doc"
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        content = _download_onlyoffice_file(
+            "http://localhost:8080/cache/files/data/demo/output.docx?x=1"
+        )
+
+        self.assertEqual(content, b"doc")
+        mock_get.assert_called_once_with(
+            "http://onlyoffice/cache/files/data/demo/output.docx?x=1",
+            timeout=7,
+        )
+
+
+class OnlyOfficeCallbackParsingTests(TestCase):
+    def setUp(self):
+        from . import views
+
+        self.views = views
+        self.original_settings = views.ONLYOFFICE_SETTINGS
+        views.ONLYOFFICE_SETTINGS = {
+            "jwt_secret": "change-me",
+        }
+        self.addCleanup(self._restore_settings)
+        self.factory = RequestFactory()
+
+    def _restore_settings(self):
+        self.views.ONLYOFFICE_SETTINGS = self.original_settings
+
+    def test_parse_callback_unwraps_nested_payload_from_jwt(self):
+        payload = {
+            "payload": {
+                "status": 2,
+                "url": "http://localhost:8080/cache/files/data/demo/output.docx",
+            }
+        }
+        token = jwt.encode(payload, "change-me", algorithm="HS256")
+        request = self.factory.post(
+            "/",
+            data=json.dumps({}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        parsed = _parse_onlyoffice_callback(request)
+
+        self.assertEqual(parsed["status"], 2)
+        self.assertEqual(
+            parsed["url"],
+            "http://localhost:8080/cache/files/data/demo/output.docx",
+        )
+
 
 class CollaborativeClosureTests(TestCase):
     def setUp(self):
@@ -2422,6 +2490,199 @@ class CollaborativeClosureTests(TestCase):
         new_token = parsed.path.rstrip("/").split("/")[-1]
         new_session = CollaborativeSession.objects.get(token=new_token)
         self.assertTrue(new_session.is_active)
+
+
+class ProtocolUploadFlowTests(TestCase):
+    def setUp(self):
+        self.media_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(self.media_dir, ignore_errors=True))
+        override = override_settings(MEDIA_ROOT=self.media_dir)
+        override.enable()
+        self.addCleanup(override.disable)
+
+        self.project = Project.objects.create(title="Ibrahim Protocol Pilot")
+        self.ibrahim = User.objects.create_user(username="ibrahim", password="pw")
+        UserRole.objects.create(user=self.ibrahim, project=self.project, role="author")
+        self.client.force_login(self.ibrahim)
+
+    def test_initial_protocol_upload_creates_revision_and_redirects(self):
+        response = self.client.post(
+            reverse("synopsis:protocol_detail", args=[self.project.id]),
+            {
+                "stage": "draft",
+                "change_reason": "",
+                "version_label": "v1.0",
+                "document": SimpleUploadedFile(
+                    "ibrahim-protocol.docx",
+                    b"protocol",
+                    content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ),
+            },
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("synopsis:protocol_detail", args=[self.project.id]),
+        )
+        protocol = Protocol.objects.get(project=self.project)
+        self.assertTrue(protocol.document.name.endswith(".docx"))
+        self.assertIsNotNone(protocol.current_revision)
+        self.assertEqual(protocol.current_revision.version_label, "v1.0")
+
+
+class OnlyOfficeConfigTests(TestCase):
+    def setUp(self):
+        from . import views
+
+        self.views = views
+        self.original_settings = views.ONLYOFFICE_SETTINGS
+        views.ONLYOFFICE_SETTINGS = {
+            "base_url": "http://localhost:8080",
+            "internal_url": "http://onlyoffice",
+            "app_base_url": "http://host.docker.internal:8000",
+            "jwt_secret": "change-me",
+            "callback_timeout": 10,
+            "trusted_download_urls": [
+                "http://localhost:8080",
+                "http://onlyoffice",
+            ],
+        }
+        self.addCleanup(self._restore_settings)
+
+        self.media_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(self.media_dir, ignore_errors=True))
+        override = override_settings(MEDIA_ROOT=self.media_dir)
+        override.enable()
+        self.addCleanup(override.disable)
+
+        self.factory = RequestFactory()
+        self.project = Project.objects.create(title="Will Collaboration Test")
+        self.ibrahim = User.objects.create_user(username="ibrahim-editor", password="pw")
+        UserRole.objects.create(user=self.ibrahim, project=self.project, role="author")
+        self.protocol = Protocol.objects.create(
+            project=self.project,
+            document=SimpleUploadedFile(
+                "will-protocol.docx",
+                b"protocol",
+                content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ),
+        )
+        self.session = CollaborativeSession.objects.create(
+            project=self.project,
+            document_type=CollaborativeSession.DOCUMENT_PROTOCOL,
+            started_by=self.ibrahim,
+            last_activity_at=timezone.now(),
+        )
+
+    def _restore_settings(self):
+        self.views.ONLYOFFICE_SETTINGS = self.original_settings
+
+    def test_config_uses_internal_app_base_for_document_and_callback_urls(self):
+        request = self.factory.get("/", HTTP_HOST="localhost:8000")
+        request.user = self.ibrahim
+
+        config = _build_onlyoffice_config(
+            request,
+            self.project,
+            self.protocol,
+            self.session,
+            CollaborativeSession.DOCUMENT_PROTOCOL,
+        )
+
+        self.assertTrue(
+            config["document"]["url"].startswith("http://host.docker.internal:8000/")
+        )
+        self.assertTrue(
+            config["editorConfig"]["callbackUrl"].startswith(
+                "http://host.docker.internal:8000/"
+            )
+        )
+
+
+class CollaborativeForceSaveCloseTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(title="Will Final Save")
+        self.manager = User.objects.create_user(username="ibrahim-manager", password="pw")
+        self.manager.is_staff = True
+        self.manager.save(update_fields=["is_staff"])
+        UserRole.objects.create(user=self.manager, project=self.project, role="manager")
+        self.client.force_login(self.manager)
+        self.protocol = Protocol.objects.create(
+            project=self.project,
+            document=SimpleUploadedFile("will-protocol.docx", b"protocol"),
+        )
+        self.session = CollaborativeSession.objects.create(
+            project=self.project,
+            document_type=CollaborativeSession.DOCUMENT_PROTOCOL,
+            started_by=self.manager,
+            last_activity_at=timezone.now(),
+        )
+        self.url = reverse(
+            "synopsis:collaborative_force_end",
+            args=[self.project.id, "protocol", self.session.token],
+        )
+
+    @patch("synopsis.views._wait_for_collaborative_save", return_value=False)
+    @patch(
+        "synopsis.views._request_onlyoffice_forcesave",
+        return_value=(False, "Unable to request a final save from OnlyOffice."),
+    )
+    def test_force_end_keeps_session_open_when_save_request_fails(
+        self, mock_request, mock_wait
+    ):
+        response = self.client.post(self.url, {"reason": "Close from portal"})
+
+        self.assertRedirects(
+            response,
+            reverse("synopsis:protocol_detail", args=[self.project.id]),
+        )
+        self.session.refresh_from_db()
+        self.assertTrue(self.session.is_active)
+        messages_list = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any("session is still open" in message for message in messages_list),
+            messages_list,
+        )
+        mock_request.assert_called_once()
+        mock_wait.assert_called_once()
+
+    @patch("synopsis.views._wait_for_collaborative_save", return_value=True)
+    @patch(
+        "synopsis.views._request_onlyoffice_forcesave",
+        return_value=(True, "Final save requested from OnlyOffice."),
+    )
+    def test_force_end_reports_success_after_final_save(
+        self, mock_request, mock_wait
+    ):
+        response = self.client.post(self.url, {"reason": "Close from portal"})
+
+        self.assertRedirects(
+            response,
+            reverse("synopsis:protocol_detail", args=[self.project.id]),
+        )
+        messages_list = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertIn(
+            "Protocol saved and collaborative session closed.",
+            messages_list,
+        )
+        mock_request.assert_called_once()
+        mock_wait.assert_called_once()
+
+
+class MediaServingUrlTests(SimpleTestCase):
+    def test_media_route_added_when_serve_media_enabled_without_debug(self):
+        import ce_portal.urls as project_urls
+
+        with override_settings(DEBUG=False, SERVE_MEDIA=True):
+            reloaded = importlib.reload(project_urls)
+            try:
+                route_texts = [str(pattern.pattern) for pattern in reloaded.urlpatterns]
+                self.assertTrue(
+                    any(text.startswith("^media/") for text in route_texts),
+                    route_texts,
+                )
+            finally:
+                importlib.reload(project_urls)
 
 
 class CollaborativePanelViewTests(TestCase):

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -80,6 +80,8 @@ from .utils import (
 )
 from .views import (
     _advisory_board_context,
+    _apply_revision_to_action_list,
+    _apply_revision_to_protocol,
     _build_advisory_invitation_email,
     _build_onlyoffice_config,
     _download_onlyoffice_file,
@@ -2977,6 +2979,12 @@ class RevisionDeleteViewTests(TestCase):
             ).exists()
         )
 
+    def test_apply_protocol_revision_does_not_duplicate_upload_prefix(self):
+        _apply_revision_to_protocol(self.protocol, self.rev1)
+        self.protocol.refresh_from_db()
+        self.assertTrue(self.protocol.document.name.startswith("protocols/"))
+        self.assertNotIn("protocols/protocols/", self.protocol.document.name)
+
     def test_non_editor_cannot_delete_protocol_revision(self):
         request = self.factory.post(
             f"/project/{self.project.id}/protocol/revision/{self.rev1.id}/delete/"
@@ -3007,6 +3015,12 @@ class RevisionDeleteViewTests(TestCase):
                 project=self.project, action__icontains="Action list revision deleted"
             ).exists()
         )
+
+    def test_apply_action_list_revision_does_not_duplicate_upload_prefix(self):
+        _apply_revision_to_action_list(self.action_list, self.al_rev1)
+        self.action_list.refresh_from_db()
+        self.assertTrue(self.action_list.document.name.startswith("action_lists/"))
+        self.assertNotIn("action_lists/action_lists/", self.action_list.document.name)
 
     def test_non_editor_cannot_delete_action_list_revision(self):
         request = self.factory.post(
@@ -3086,7 +3100,7 @@ class ViewHelperTests(TestCase):
         self.assertTrue(_user_is_manager(user))
 
     def test_user_is_manager_for_group_member(self):
-        group = Group.objects.create(name="manager")
+        group, _ = Group.objects.get_or_create(name="manager")
         user = User.objects.create_user(username="manager_user")
         user.groups.add(group)
         self.assertTrue(_user_is_manager(user))

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -2653,7 +2653,7 @@ class CollaborativeForceSaveCloseTests(TestCase):
             messages_list,
         )
         mock_request.assert_called_once()
-        mock_wait.assert_called_once()
+        mock_wait.assert_not_called()
 
     @patch("synopsis.views._wait_for_collaborative_save", return_value=True)
     @patch(

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1215,14 +1215,14 @@ def _onlyoffice_command_headers(payload: dict) -> dict[str, str]:
     return headers
 
 
-def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[bool, str]:
+def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[str, str]:
     command_url = _onlyoffice_command_url()
     if not command_url:
         logger.warning(
             "OnlyOffice force-save skipped for session %s because command URL is missing",
             session.pk,
         )
-        return False, "Collaborative save is not configured correctly."
+        return "failed", "Collaborative save is not configured correctly."
 
     payload = {
         "c": "forcesave",
@@ -1244,18 +1244,27 @@ def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[bool
             session.pk,
             exc,
         )
-        return False, "Unable to request a final save from OnlyOffice."
+        return "failed", "Unable to request a final save from OnlyOffice."
 
     error_code = data.get("error", 1) if isinstance(data, dict) else 1
+    if error_code in {0, "0"}:
+        return "requested", "Final save requested from OnlyOffice."
+
+    if error_code in {4, "4"}:
+        logger.info(
+            "OnlyOffice force-save reported no pending changes for session %s: %s",
+            session.pk,
+            data,
+        )
+        return "noop", "No unsaved changes were pending in OnlyOffice."
+
     if error_code not in {0, "0"}:
         logger.error(
             "OnlyOffice force-save request returned error for session %s: %s",
             session.pk,
             data,
         )
-        return False, "OnlyOffice did not accept the final save request."
-
-    return True, "Final save requested from OnlyOffice."
+        return "failed", "OnlyOffice did not accept the final save request."
 
 
 def _wait_for_collaborative_save(session, document_type, timeout_seconds: int) -> bool:
@@ -3990,9 +3999,22 @@ def collaborative_force_end(request, project_id, document_slug, token):
 
     reason = (request.POST.get("reason") or "").strip() or "Session ended from portal"
     document_label = _document_label(document_type)
-    requested, save_message = _request_onlyoffice_forcesave(
+    save_state, save_message = _request_onlyoffice_forcesave(
         project, document_type, session
     )
+    if save_state == "noop":
+        session.mark_inactive(reason=reason)
+        _log_project_change(
+            project,
+            request.user,
+            f"{document_label} collaborative session closed",
+            f"Session {session.token} closed with no unsaved changes.",
+        )
+        messages.success(
+            request, f"{document_label} had no unsaved changes and the session was closed."
+        )
+        return redirect(_document_detail_url(project.id, document_type))
+
     if _wait_for_collaborative_save(
         session,
         document_type,
@@ -4003,7 +4025,7 @@ def collaborative_force_end(request, project_id, document_slug, token):
         )
         return redirect(_document_detail_url(project.id, document_type))
 
-    if not requested:
+    if save_state != "requested":
         messages.error(
             request,
             f"{save_message} The session is still open so no edits are discarded.",

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -8,12 +8,13 @@ import re
 import random
 import uuid
 from decimal import Decimal
-from urllib.parse import urlparse, urlencode
+from urllib.parse import urljoin, urlparse, urlencode, urlunparse
 
 import jwt
 import requests
 import rispy
 import html
+import time
 from defusedxml import ElementTree as ET
 
 from django.conf import settings
@@ -979,9 +980,29 @@ def _onlyoffice_editor_js_url() -> str:
     return f"{base}/web-apps/apps/api/documents/api.js"
 
 
+def _onlyoffice_service_base_url() -> str:
+    return (
+        (ONLYOFFICE_SETTINGS.get("internal_url") or "").rstrip("/")
+        or (ONLYOFFICE_SETTINGS.get("base_url") or "").rstrip("/")
+    )
+
+
+def _onlyoffice_app_absolute_uri(request, path: str) -> str:
+    base = (ONLYOFFICE_SETTINGS.get("app_base_url") or "").rstrip("/")
+    if not base:
+        return request.build_absolute_uri(path)
+    return urljoin(f"{base}/", path.lstrip("/"))
+
+
 def _document_filetype(file_name: str) -> str:
     ext = (os.path.splitext(file_name)[1] or "").lstrip(".").lower()
     return ext or "docx"
+
+
+def _collaborative_document_key(project, document_type, session) -> str:
+    return f"{project.id}-{document_type}-{session.id}-{int(session.started_at.timestamp())}"[
+        -128:
+    ]
 
 
 def _build_onlyoffice_config(
@@ -996,12 +1017,10 @@ def _build_onlyoffice_config(
     if not document_file:
         raise ValueError("Document has no file attached")
 
-    file_url = request.build_absolute_uri(document_file.url)
+    file_url = _onlyoffice_app_absolute_uri(request, document_file.url)
     file_type = _document_filetype(document_file.name)
     title = os.path.basename(document_file.name) or _document_label(document_type)
-    doc_key = f"{project.id}-{document_type}-{session.id}-{int(session.started_at.timestamp())}"[
-        -128:
-    ]
+    doc_key = _collaborative_document_key(project, document_type, session)
 
     user = request.user
     user_id = str(getattr(user, "id", "anonymous"))
@@ -1017,7 +1036,8 @@ def _build_onlyoffice_config(
         user_name = participant.get("name", user_name)
         user_email = participant.get("email", user_email)
 
-    callback_url = request.build_absolute_uri(
+    callback_url = _onlyoffice_app_absolute_uri(
+        request,
         reverse(
             "synopsis:collaborative_edit_callback",
             args=[project.id, _document_type_slug(document_type), session.token],
@@ -1065,7 +1085,11 @@ def _build_onlyoffice_config(
 
 
 def _download_onlyoffice_file(file_url: str) -> bytes:
-    raw_entries = [ONLYOFFICE_SETTINGS.get("base_url", "")]
+    file_url = _onlyoffice_internal_download_url(file_url)
+    raw_entries = [
+        ONLYOFFICE_SETTINGS.get("base_url", ""),
+        ONLYOFFICE_SETTINGS.get("internal_url", ""),
+    ]
     extra = ONLYOFFICE_SETTINGS.get("trusted_download_urls") or []
     if isinstance(extra, (list, tuple)):
         raw_entries.extend(extra)
@@ -1138,6 +1162,120 @@ def _onlyoffice_secret() -> str:
     return ONLYOFFICE_SETTINGS.get("jwt_secret", "")
 
 
+def _onlyoffice_internal_download_url(file_url: str) -> str:
+    base = (ONLYOFFICE_SETTINGS.get("base_url") or "").rstrip("/")
+    internal = (ONLYOFFICE_SETTINGS.get("internal_url") or "").rstrip("/")
+    if not base or not internal:
+        return file_url
+
+    try:
+        parsed_file = urlparse(file_url)
+        parsed_base = urlparse(base)
+        parsed_internal = urlparse(internal)
+    except ValueError:
+        return file_url
+
+    if (
+        parsed_file.scheme != parsed_base.scheme
+        or parsed_file.hostname != parsed_base.hostname
+        or (parsed_file.port or (443 if parsed_file.scheme == "https" else 80))
+        != (parsed_base.port or (443 if parsed_base.scheme == "https" else 80))
+    ):
+        return file_url
+
+    replacement_netloc = parsed_internal.netloc or parsed_file.netloc
+    return urlunparse(
+        (
+            parsed_internal.scheme or parsed_file.scheme,
+            replacement_netloc,
+            parsed_file.path,
+            parsed_file.params,
+            parsed_file.query,
+            parsed_file.fragment,
+        )
+    )
+
+
+def _onlyoffice_command_url() -> str:
+    base = _onlyoffice_service_base_url()
+    if not base:
+        return ""
+    return f"{base}/coauthoring/CommandService.ashx"
+
+
+def _onlyoffice_command_headers(payload: dict) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    secret = _onlyoffice_secret()
+    if not secret:
+        return headers
+    token = jwt.encode(payload, secret, algorithm="HS256")
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+    headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[bool, str]:
+    command_url = _onlyoffice_command_url()
+    if not command_url:
+        logger.warning(
+            "OnlyOffice force-save skipped for session %s because command URL is missing",
+            session.pk,
+        )
+        return False, "Collaborative save is not configured correctly."
+
+    payload = {
+        "c": "forcesave",
+        "key": _collaborative_document_key(project, document_type, session),
+    }
+    timeout = ONLYOFFICE_SETTINGS.get("callback_timeout", 10)
+    try:
+        response = requests.post(
+            command_url,
+            json=payload,
+            headers=_onlyoffice_command_headers(payload),
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.error(
+            "OnlyOffice force-save request failed for session %s: %s",
+            session.pk,
+            exc,
+        )
+        return False, "Unable to request a final save from OnlyOffice."
+
+    error_code = data.get("error", 1) if isinstance(data, dict) else 1
+    if error_code not in {0, "0"}:
+        logger.error(
+            "OnlyOffice force-save request returned error for session %s: %s",
+            session.pk,
+            data,
+        )
+        return False, "OnlyOffice did not accept the final save request."
+
+    return True, "Final save requested from OnlyOffice."
+
+
+def _wait_for_collaborative_save(session, document_type, timeout_seconds: int) -> bool:
+    deadline = time.monotonic() + max(timeout_seconds, 1)
+    result_field = (
+        "result_protocol_revision_id"
+        if document_type == CollaborativeSession.DOCUMENT_PROTOCOL
+        else "result_action_list_revision_id"
+    )
+
+    while time.monotonic() < deadline:
+        session.refresh_from_db()
+        if getattr(session, result_field):
+            return True
+        time.sleep(0.5)
+
+    session.refresh_from_db()
+    return bool(getattr(session, result_field))
+
+
 def _extract_onlyoffice_token(request, payload: dict) -> str | None:
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
@@ -1176,6 +1314,10 @@ def _parse_onlyoffice_callback(request) -> dict:
     if not isinstance(decoded, dict):
         logger.warning("OnlyOffice callback token did not decode to a JSON object")
         raise PermissionDenied("Invalid callback payload")
+
+    nested_payload = decoded.get("payload")
+    if isinstance(nested_payload, dict):
+        return nested_payload
 
     return decoded
 
@@ -2707,11 +2849,6 @@ def protocol_detail(request, project_id):
             stage_changed = bool(protocol) and protocol.stage != new_stage
             replacing_file = bool(uploaded_file)
             previous_label = (
-                (action_list.current_revision.version_label or "")
-                if action_list and action_list.current_revision
-                else ""
-            )
-            previous_label = (
                 (protocol.current_revision.version_label or "")
                 if protocol and protocol.current_revision
                 else ""
@@ -3852,21 +3989,30 @@ def collaborative_force_end(request, project_id, document_slug, token):
         return redirect(_document_detail_url(project.id, document_type))
 
     reason = (request.POST.get("reason") or "").strip() or "Session ended from portal"
-    session.change_summary = session.change_summary or reason
-    session.mark_inactive(
-        ended_by=request.user,
-        reason=reason,
-        extra_updates=["change_summary"],
-    )
-
     document_label = _document_label(document_type)
-    _log_project_change(
-        project,
-        request.user,
-        f"{document_label} collaborative session ended",
-        f"Session {session.token} ended manually ({reason}).",
+    requested, save_message = _request_onlyoffice_forcesave(
+        project, document_type, session
     )
-    messages.success(request, f"{document_label} collaborative session closed.")
+    if _wait_for_collaborative_save(
+        session,
+        document_type,
+        timeout_seconds=ONLYOFFICE_SETTINGS.get("callback_timeout", 10),
+    ):
+        messages.success(
+            request, f"{document_label} saved and collaborative session closed."
+        )
+        return redirect(_document_detail_url(project.id, document_type))
+
+    if not requested:
+        messages.error(
+            request,
+            f"{save_message} The session is still open so no edits are discarded.",
+        )
+    else:
+        messages.warning(
+            request,
+            f"{save_message} The session is still open while OnlyOffice finishes saving.",
+        )
     return redirect(_document_detail_url(project.id, document_type))
 
 

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -761,7 +761,7 @@ def _apply_revision_to_protocol(protocol, revision) -> tuple[str, str]:
         raise ValueError("Revision file empty")
 
     base_name = revision.original_name or os.path.basename(revision.file.name)
-    new_filename = f"protocols/{uuid.uuid4()}_{base_name}"
+    new_filename = f"{uuid.uuid4()}_{base_name}"
     protocol.document.save(new_filename, ContentFile(content), save=False)
     protocol.current_revision = revision
     protocol.save(update_fields=["document", "current_revision"])
@@ -779,7 +779,7 @@ def _apply_revision_to_action_list(action_list, revision) -> tuple[str, str]:
         raise ValueError("Revision file empty")
 
     base_name = revision.original_name or os.path.basename(revision.file.name)
-    new_filename = f"action_lists/{uuid.uuid4()}_{base_name}"
+    new_filename = f"{uuid.uuid4()}_{base_name}"
     action_list.document.save(new_filename, ContentFile(content), save=False)
     action_list.current_revision = revision
     action_list.save(update_fields=["document", "current_revision"])

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -4003,12 +4003,17 @@ def collaborative_force_end(request, project_id, document_slug, token):
         project, document_type, session
     )
     if save_state == "noop":
-        session.mark_inactive(reason=reason)
+        session.change_summary = session.change_summary or reason
+        session.mark_inactive(
+            ended_by=request.user,
+            reason=reason,
+            extra_updates=["change_summary"],
+        )
         _log_project_change(
             project,
             request.user,
             f"{document_label} collaborative session closed",
-            f"Session {session.token} closed with no unsaved changes.",
+            f"Session {session.token} closed with no unsaved changes ({reason}).",
         )
         messages.success(
             request, f"{document_label} had no unsaved changes and the session was closed."

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -4015,25 +4015,24 @@ def collaborative_force_end(request, project_id, document_slug, token):
         )
         return redirect(_document_detail_url(project.id, document_type))
 
-    if _wait_for_collaborative_save(
-        session,
-        document_type,
-        timeout_seconds=ONLYOFFICE_SETTINGS.get("callback_timeout", 10),
-    ):
-        messages.success(
-            request, f"{document_label} saved and collaborative session closed."
-        )
-        return redirect(_document_detail_url(project.id, document_type))
-
-    if save_state != "requested":
-        messages.error(
-            request,
-            f"{save_message} The session is still open so no edits are discarded.",
-        )
-    else:
+    if save_state == "requested":
+        if _wait_for_collaborative_save(
+            session,
+            document_type,
+            timeout_seconds=ONLYOFFICE_SETTINGS.get("callback_timeout", 10),
+        ):
+            messages.success(
+                request, f"{document_label} saved and collaborative session closed."
+            )
+            return redirect(_document_detail_url(project.id, document_type))
         messages.warning(
             request,
             f"{save_message} The session is still open while OnlyOffice finishes saving.",
+        )
+    else:
+        messages.error(
+            request,
+            f"{save_message} The session is still open so no edits are discarded.",
         )
     return redirect(_document_detail_url(project.id, document_type))
 

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -24,10 +24,10 @@
             method="post"
             action="{{ force_end_url }}"
             class="d-inline"
-            onsubmit="return confirm('End this collaborative session for everyone?');"
+            onsubmit="return confirm('Request a final save and end this collaborative session for everyone?');"
         >
             {% csrf_token %}
-            <button type="submit" class="btn btn-outline-danger btn-sm">End session</button>
+            <button type="submit" class="btn btn-outline-danger btn-sm">Save and end session</button>
         </form>
         {% endif %}
     </div>

--- a/src/templates/synopsis/includes/collaborative_panel.html
+++ b/src/templates/synopsis/includes/collaborative_panel.html
@@ -32,10 +32,10 @@
                 method="post"
                 action="{{ collaborative_force_end_url }}"
                 class="d-inline"
-                onsubmit="return confirm('End this collaborative session for everyone?');"
+                onsubmit="return confirm('Request a final save and end this collaborative session for everyone?');"
             >
                 {% csrf_token %}
-                <button type="submit" class="btn btn-outline-danger btn-sm">End session</button>
+                <button type="submit" class="btn btn-outline-danger btn-sm">Save and end session</button>
             </form>
             {% endif %}
         </div>


### PR DESCRIPTION
# Pull Request
<!-- Please fill out the following sections to the best of your ability. You may skip any sections that are not mandatory or relevant by putting 'N/A' inside the sub-section. -->

_Please answer the following sections before submitting your PR:_

## Type of Change
<!-- Mandatory -->
- [x] Bug fix
- [x] New feature
- [ ] Enhancement
- [x] Documentation update
- [x] Code refactoring
- [ ] Other (please describe):

## Related Issues
<!-- Mandatory -->
Fixes #(issue number)
Addresses #(issue number)
Enhancements #(issue number)

#### 1 Why was this PR needed?
This PR prepares the project for an online pilot deployment with OnlyOffice by improving collaborative-session closure behavior, adding Docker/Gunicorn deployment assets, and making environment/configuration handling more production-friendly.

#### 2 What changed?
Changes:

- Add OnlyOffice “force-save then close” flow helpers, internal/app URL handling, and improved callback parsing.
- Introduce Docker deployment stack (Gunicorn, Postgres, OnlyOffice, optional Caddy) plus static/media serving and updated settings/env handling.
- Add/adjust tests and documentation for the new pilot deployment and collaborative editing behavior.

#### 3 Backward compatibility & risk
N/A

#### 4 Files changed
See files changed for full details.

#### 5 Other changes
Added documentation for docker and instructions (draft) for hosting.

## Testing & Results
<!-- Mandatory -->
Modified some tests but all tests passed.

## Checklist
<!-- Mandatory -->
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my changes work
- [x] All new and existing tests pass
- [x] My changes follow the established code style guidelines

## Screenshots (if applicable)
<!-- Optional -->
_Add screenshots here if needed_

## Notes
<!-- Optional -->
e.g. additional information, context, or comments for reviewers.