### PR TITLE
Fix collab editor session simplification

### DIFF
--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4832,12 +4832,32 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response.context["editor_config"]["editorConfig"]["user"]["id"],
             f"abm:{self.member.id}",
         )
-        self.assertContains(response, "You are editing as Asha Reviewer.")
-        self.assertContains(response, "How to use this editor")
+        self.assertFalse(response.context["editor_config"]["document"]["permissions"]["edit"])
+        self.assertTrue(response.context["editor_config"]["document"]["permissions"]["comment"])
+        self.assertFalse(response.context["editor_config"]["document"]["permissions"]["review"])
+        self.assertContains(response, "You are signed in as")
+        self.assertContains(response, "Asha Reviewer")
+        self.assertContains(response, "How to review this document")
         self.assertContains(
             response,
-            "Use <strong>Leave editor</strong> when you are finished. This leaves the page without closing the shared session for anyone else.",
+            "Advisory board feedback is collected as comments so the authors can review each suggestion and decide what to change.",
+        )
+        self.assertContains(
+            response,
+            "Highlight the relevant text and use the comment button in the editor toolbar, or right-click the highlighted text and choose the comment option.",
+        )
+        self.assertContains(
+            response,
+            "Place the cursor near the relevant section first, then add the comment from the toolbar so the authors can see what part of the document it refers to.",
+        )
+        self.assertContains(
+            response,
+            "Use <strong>Leave editor</strong>. This does not close the shared session for anyone else, and you can reopen the same link later while the feedback window is still open.",
             html=True,
+        )
+        self.assertContains(
+            response,
+            "Comment-only access",
         )
         self.assertNotContains(response, "How collaborative editing works")
 
@@ -4860,7 +4880,10 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response.context["editor_config"]["editorConfig"]["user"]["id"],
             f"abm:{self.member.id}",
         )
-        self.assertContains(response, "How to use this editor")
+        self.assertFalse(response.context["editor_config"]["document"]["permissions"]["edit"])
+        self.assertTrue(response.context["editor_config"]["document"]["permissions"]["comment"])
+        self.assertFalse(response.context["editor_config"]["document"]["permissions"]["review"])
+        self.assertContains(response, "How to review this document")
         self.assertNotContains(response, "How collaborative editing works")
 
     def test_anonymous_reviewer_invitation_link_restarts_when_session_is_closed(self):
@@ -4935,6 +4958,9 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response.context["editor_config"]["editorConfig"]["user"]["id"],
             str(self.author.id),
         )
+        self.assertTrue(response.context["editor_config"]["document"]["permissions"]["edit"])
+        self.assertTrue(response.context["editor_config"]["document"]["permissions"]["comment"])
+        self.assertTrue(response.context["editor_config"]["document"]["permissions"]["review"])
         self.assertContains(response, "Leave editor")
         self.assertContains(
             response,

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4837,28 +4837,31 @@ class OnlyOfficeExternalAccessTests(TestCase):
         self.assertFalse(response.context["editor_config"]["document"]["permissions"]["review"])
         self.assertContains(response, "You are signed in as")
         self.assertContains(response, "Asha Reviewer")
-        self.assertContains(response, "How to review this document")
         self.assertContains(
             response,
-            "Advisory board feedback is collected as comments so the authors can review each suggestion and decide what to change.",
+            "To comment, highlight text and use the comment button in the toolbar.",
         )
         self.assertContains(
             response,
-            "Highlight the relevant text and use the comment button in the editor toolbar, or right-click the highlighted text and choose the comment option.",
+            "Authors will review your comments and decide whether to apply them.",
         )
         self.assertContains(
             response,
-            "Place the cursor near the relevant section first, then add the comment from the toolbar so the authors can see what part of the document it refers to.",
+            "Comments save automatically while you work.",
         )
         self.assertContains(
             response,
-            "Use <strong>Leave editor</strong>. This does not close the shared session for anyone else, and you can reopen the same link later while the feedback window is still open.",
-            html=True,
+            "Comments accepted until",
+        )
+        self.assertContains(
+            response,
+            _format_deadline(self.member.feedback_on_protocol_deadline),
         )
         self.assertContains(
             response,
             "Comment-only access",
         )
+        self.assertContains(response, "Leave review page")
         self.assertNotContains(response, "How collaborative editing works")
 
     def test_anonymous_reviewer_can_open_editor_with_invitation_token(self):
@@ -4883,7 +4886,8 @@ class OnlyOfficeExternalAccessTests(TestCase):
         self.assertFalse(response.context["editor_config"]["document"]["permissions"]["edit"])
         self.assertTrue(response.context["editor_config"]["document"]["permissions"]["comment"])
         self.assertFalse(response.context["editor_config"]["document"]["permissions"]["review"])
-        self.assertContains(response, "How to review this document")
+        self.assertContains(response, "Comments accepted until")
+        self.assertContains(response, "Leave review page")
         self.assertNotContains(response, "How collaborative editing works")
 
     def test_anonymous_reviewer_invitation_link_restarts_when_session_is_closed(self):
@@ -4996,9 +5000,9 @@ class OnlyOfficeExternalAccessTests(TestCase):
         self.assertTrue(self.session.is_active)
         self.assertContains(
             response,
-            "You left the collaborative editor. This did not close the shared session for other participants.",
+            "You left the review page. This did not close the shared session for other participants.",
         )
-        self.assertContains(response, "Reopen editor")
+        self.assertContains(response, "Reopen review page")
         self.assertContains(response, "Close this tab")
 
 class CollaborativeForceSaveCloseTests(TestCase):

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4976,6 +4976,8 @@ class OnlyOfficeExternalAccessTests(TestCase):
             "To save and close the shared session for everyone, return to the protocol detail page.",
         )
         self.assertContains(response, "Active in this document:")
+        self.assertContains(response, "visibilitychange")
+        self.assertContains(response, "startPresencePolling")
         self.assertNotContains(response, "reviewer-tab-lock-key")
         self.assertNotContains(response, "How collaborative editing works")
         self.assertNotContains(

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4874,6 +4874,44 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response.context["editor_config"]["editorConfig"]["user"]["id"],
             str(self.author.id),
         )
+        self.assertContains(response, "Leave editor")
+        self.assertContains(
+            response,
+            "To save and close the shared session for everyone, return to the protocol detail page.",
+        )
+        self.assertNotContains(
+            response,
+            reverse(
+                "synopsis:collaborative_force_end",
+                args=[self.project.id, "protocol", self.session.token],
+            ),
+        )
+
+    def test_anonymous_reviewer_can_leave_editor_without_closing_shared_session(self):
+        feedback = ProtocolFeedback.objects.create(
+            project=self.project,
+            member=self.member,
+            email=self.member.email,
+            feedback_deadline_at=self.member.feedback_on_protocol_deadline,
+        )
+
+        response = self.client.get(
+            reverse(
+                "synopsis:collaborative_leave",
+                args=[self.project.id, "protocol", self.session.token],
+            )
+            + f"?feedback={feedback.token}"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.session.refresh_from_db()
+        self.assertTrue(self.session.is_active)
+        self.assertContains(
+            response,
+            "You left the collaborative editor. This did not close the shared session for other participants.",
+        )
+        self.assertContains(response, "Reopen editor")
+        self.assertContains(response, "Close this tab")
 
 class CollaborativeForceSaveCloseTests(TestCase):
     def setUp(self):
@@ -5080,6 +5118,44 @@ class CollaborativePanelViewTests(TestCase):
         )
         self.assertNotContains(
             response, "Upload the action list before starting a collaborative session."
+        )
+
+    def test_protocol_panel_active_session_explains_global_close_scope(self):
+        from . import views
+
+        original_settings = views.ONLYOFFICE_SETTINGS
+        views.ONLYOFFICE_SETTINGS = {
+            "base_url": "http://localhost:8080",
+            "internal_url": "http://onlyoffice",
+            "app_base_url": "http://web:8000",
+            "jwt_secret": "change-me",
+            "callback_timeout": 10,
+            "trusted_download_urls": [
+                "http://localhost:8080",
+                "http://onlyoffice",
+            ],
+        }
+        self.addCleanup(lambda: setattr(views, "ONLYOFFICE_SETTINGS", original_settings))
+
+        Protocol.objects.create(
+            project=self.project,
+            document=SimpleUploadedFile("protocol.docx", b"protocol"),
+        )
+        CollaborativeSession.objects.create(
+            project=self.project,
+            document_type=CollaborativeSession.DOCUMENT_PROTOCOL,
+            started_by=self.user,
+            last_activity_at=timezone.now(),
+        )
+
+        response = self.client.get(
+            reverse("synopsis:protocol_detail", args=[self.project.id])
+        )
+
+        self.assertContains(response, "Save and close session for everyone")
+        self.assertContains(
+            response,
+            "Participants can leave the editor without using this button. Use this only when everyone is finished.",
         )
 
     def test_advisory_board_shows_custom_columns_button_and_not_document_feedback_windows(self):

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4863,6 +4863,58 @@ class OnlyOfficeExternalAccessTests(TestCase):
         self.assertContains(response, "How to use this editor")
         self.assertNotContains(response, "How collaborative editing works")
 
+    def test_anonymous_reviewer_invitation_link_restarts_when_session_is_closed(self):
+        invitation = AdvisoryBoardInvitation.objects.create(
+            project=self.project,
+            member=self.member,
+            email=self.member.email,
+            invited_by=self.author,
+            due_date=timezone.localdate() + timedelta(days=7),
+        )
+        self.session.invitations.add(invitation)
+        original_token = self.session.token
+        self.session.mark_inactive(reason="Closed for restart test")
+
+        response = self.client.get(
+            self._editor_url(f"?invite={invitation.token}&member={self.member.id}")
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(str(invitation.token), response["Location"])
+        self.assertNotIn(str(original_token), response["Location"])
+        new_session = CollaborativeSession.objects.get(
+            project=self.project,
+            document_type=CollaborativeSession.DOCUMENT_PROTOCOL,
+            is_active=True,
+        )
+        self.assertNotEqual(new_session.token, original_token)
+        self.assertTrue(new_session.invitations.filter(pk=invitation.pk).exists())
+
+    def test_anonymous_reviewer_feedback_link_restarts_when_session_expires(self):
+        feedback = ProtocolFeedback.objects.create(
+            project=self.project,
+            member=self.member,
+            email=self.member.email,
+            feedback_deadline_at=self.member.feedback_on_protocol_deadline,
+        )
+        original_token = self.session.token
+        self.session.last_activity_at = timezone.now() - timedelta(hours=5)
+        self.session.save(update_fields=["last_activity_at"])
+
+        response = self.client.get(self._editor_url(f"?feedback={feedback.token}"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(str(feedback.token), response["Location"])
+        self.assertNotIn(str(original_token), response["Location"])
+        self.session.refresh_from_db()
+        self.assertFalse(self.session.is_active)
+        new_session = CollaborativeSession.objects.get(
+            project=self.project,
+            document_type=CollaborativeSession.DOCUMENT_PROTOCOL,
+            is_active=True,
+        )
+        self.assertNotEqual(new_session.token, original_token)
+
     def test_member_id_only_link_is_blocked_for_anonymous_users(self):
         response = self.client.get(self._editor_url(f"?member={self.member.id}"))
 

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4835,7 +4835,7 @@ class OnlyOfficeExternalAccessTests(TestCase):
         self.assertFalse(response.context["editor_config"]["document"]["permissions"]["edit"])
         self.assertTrue(response.context["editor_config"]["document"]["permissions"]["comment"])
         self.assertFalse(response.context["editor_config"]["document"]["permissions"]["review"])
-        self.assertContains(response, "You are signed in as")
+        self.assertContains(response, "Reviewing as")
         self.assertContains(response, "Asha Reviewer")
         self.assertContains(
             response,

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4833,6 +4833,13 @@ class OnlyOfficeExternalAccessTests(TestCase):
             f"abm:{self.member.id}",
         )
         self.assertContains(response, "You are editing as Asha Reviewer.")
+        self.assertContains(response, "How to use this editor")
+        self.assertContains(
+            response,
+            "Use <strong>Leave editor</strong> when you are finished. This leaves the page without closing the shared session for anyone else.",
+            html=True,
+        )
+        self.assertNotContains(response, "How collaborative editing works")
 
     def test_anonymous_reviewer_can_open_editor_with_invitation_token(self):
         invitation = AdvisoryBoardInvitation.objects.create(
@@ -4853,6 +4860,8 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response.context["editor_config"]["editorConfig"]["user"]["id"],
             f"abm:{self.member.id}",
         )
+        self.assertContains(response, "How to use this editor")
+        self.assertNotContains(response, "How collaborative editing works")
 
     def test_member_id_only_link_is_blocked_for_anonymous_users(self):
         response = self.client.get(self._editor_url(f"?member={self.member.id}"))
@@ -4879,6 +4888,7 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response,
             "To save and close the shared session for everyone, return to the protocol detail page.",
         )
+        self.assertNotContains(response, "How collaborative editing works")
         self.assertNotContains(
             response,
             reverse(

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -5002,6 +5002,13 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response,
             "You left the review page. This did not close the shared session for other participants.",
         )
+        self.assertContains(response, "Reviewing as")
+        self.assertContains(response, "Asha Reviewer")
+        self.assertContains(response, "Comment-only access")
+        self.assertContains(response, "Comments accepted until")
+        self.assertContains(
+            response, _format_deadline(self.member.feedback_on_protocol_deadline)
+        )
         self.assertContains(response, "Reopen review page")
         self.assertContains(response, "Close this tab")
 

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4862,6 +4862,11 @@ class OnlyOfficeExternalAccessTests(TestCase):
             "Comment-only access",
         )
         self.assertContains(response, "Leave review page")
+        self.assertContains(response, "reviewer-tab-lock-key")
+        self.assertContains(
+            response,
+            "This review page is already open in another tab. Return to that tab or close it before opening another one.",
+        )
         self.assertNotContains(response, "How collaborative editing works")
 
     def test_anonymous_reviewer_can_open_editor_with_invitation_token(self):
@@ -4970,6 +4975,8 @@ class OnlyOfficeExternalAccessTests(TestCase):
             response,
             "To save and close the shared session for everyone, return to the protocol detail page.",
         )
+        self.assertContains(response, "Active in this document:")
+        self.assertNotContains(response, "reviewer-tab-lock-key")
         self.assertNotContains(response, "How collaborative editing works")
         self.assertNotContains(
             response,
@@ -4977,6 +4984,33 @@ class OnlyOfficeExternalAccessTests(TestCase):
                 "synopsis:collaborative_force_end",
                 args=[self.project.id, "protocol", self.session.token],
             ),
+        )
+
+    @patch(
+        "synopsis.views._collaborative_active_participant_names",
+        return_value=["Asha Reviewer", "external-author"],
+    )
+    def test_author_can_fetch_active_collaborative_participants(
+        self, mock_active_names
+    ):
+        self.client.force_login(self.author)
+
+        response = self.client.get(
+            reverse(
+                "synopsis:collaborative_presence",
+                args=[self.project.id, "protocol", self.session.token],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"participants": ["Asha Reviewer", "external-author"]},
+        )
+        mock_active_names.assert_called_once_with(
+            self.project,
+            CollaborativeSession.DOCUMENT_PROTOCOL,
+            self.session,
         )
 
     def test_anonymous_reviewer_can_leave_editor_without_closing_shared_session(self):

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -4970,7 +4970,7 @@ class OnlyOfficeExternalAccessTests(TestCase):
         self.assertTrue(response.context["editor_config"]["document"]["permissions"]["edit"])
         self.assertTrue(response.context["editor_config"]["document"]["permissions"]["comment"])
         self.assertTrue(response.context["editor_config"]["document"]["permissions"]["review"])
-        self.assertContains(response, "Leave editor")
+        self.assertContains(response, "Back to protocol page")
         self.assertContains(
             response,
             "To save and close the shared session for everyone, return to the protocol detail page.",

--- a/src/synopsis/urls.py
+++ b/src/synopsis/urls.py
@@ -146,6 +146,11 @@ urlpatterns = [
         name="collaborative_edit",
     ),
     path(
+        "project/<int:project_id>/<slug:document_slug>/collaborative/<uuid:token>/leave/",
+        views.collaborative_leave,
+        name="collaborative_leave",
+    ),
+    path(
         "project/<int:project_id>/<slug:document_slug>/collaborative/<uuid:token>/force-end/",
         views.collaborative_force_end,
         name="collaborative_force_end",

--- a/src/synopsis/urls.py
+++ b/src/synopsis/urls.py
@@ -156,6 +156,11 @@ urlpatterns = [
         name="collaborative_force_end",
     ),
     path(
+        "project/<int:project_id>/<slug:document_slug>/collaborative/<uuid:token>/presence/",
+        views.collaborative_presence,
+        name="collaborative_presence",
+    ),
+    path(
         "project/<int:project_id>/<slug:document_slug>/collaborative/<uuid:token>/callback/",
         views.collaborative_edit_callback,
         name="collaborative_edit_callback",

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -4769,12 +4769,19 @@ def collaborative_edit(request, project_id, document_slug, token):
     participant_display = ""
     participant_context = None
     editor_access_mode = "edit"
+    review_deadline_display = ""
     if external_access.get("allowed"):
         participant_member = external_access.get("member")
         participant_feedback = external_access.get("feedback")
         participant_display = external_access.get("participant_display", "")
         participant_context = external_access.get("participant_context")
         editor_access_mode = external_access.get("editor_access_mode", "comment")
+        if editor_access_mode == "comment":
+            review_deadline = _member_feedback_deadline(
+                participant_member, document_type
+            ) or getattr(participant_feedback, "feedback_deadline_at", None)
+            if review_deadline:
+                review_deadline_display = _format_deadline(review_deadline)
 
     if not participant_member and not participant_context and user_can_edit:
         member_id = request.GET.get("member")
@@ -4857,6 +4864,7 @@ def collaborative_edit(request, project_id, document_slug, token):
             "leave_url": leave_url,
             "participant_display": participant_display,
             "editor_comment_only": editor_access_mode == "comment",
+            "review_deadline_display": review_deadline_display,
         },
     )
 
@@ -4893,6 +4901,7 @@ def collaborative_leave(request, project_id, document_slug, token):
 
     reopen_url = ""
     document = _get_document_for_type(project, document_type)
+    reviewer_comment_only = external_access.get("editor_access_mode") == "comment"
     if (
         session.is_active
         and not session.has_expired()
@@ -4911,9 +4920,14 @@ def collaborative_leave(request, project_id, document_slug, token):
             "document_label": document_label,
             "detail_url": project_editor_detail_url,
             "leave_message": (
-                "You left the collaborative editor. This did not close the shared session for other participants."
+                "You left the review page. This did not close the shared session for other participants."
+                if reviewer_comment_only
+                else "You left the collaborative editor. This did not close the shared session for other participants."
             ),
             "reopen_url": reopen_url,
+            "reopen_label": (
+                "Reopen review page" if reviewer_comment_only else "Reopen editor"
+            ),
             "can_force_end": False,
             "force_end_url": "",
             "leave_url": "",

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1586,6 +1586,21 @@ def _collaborative_query_suffix(querydict) -> str:
     return f"?{query_string}" if query_string else ""
 
 
+def _restart_external_collaborative_url(
+    request, project, document_type, external_access
+) -> str:
+    if not external_access.get("allowed"):
+        return ""
+    return _ensure_collaborative_invite_link(
+        request,
+        project,
+        document_type,
+        external_access.get("invitation"),
+        member=external_access.get("member"),
+        feedback=external_access.get("feedback"),
+    )
+
+
 def _build_onlyoffice_config(
     request,
     project,
@@ -4627,28 +4642,35 @@ def collaborative_edit(request, project_id, document_slug, token):
         )
 
     session = _collaborative_session_or_404(project, document_type, token)
+    external_access = {"allowed": False}
+    if not user_can_edit:
+        external_access = _resolve_external_collaborative_access(
+            request, project, document_type, session
+        )
+        if not external_access.get("allowed"):
+            return _collaborative_access_closed_response(
+                request,
+                project,
+                document_label,
+                external_access.get("message")
+                or "You do not have access to this collaborative session.",
+            )
+
     if session.has_expired():
         session.mark_inactive(reason="Session expired")
         if user_can_edit:
             messages.warning(request, "This collaborative session has expired.")
             return redirect(detail_url)
+        restart_url = _restart_external_collaborative_url(
+            request, project, document_type, external_access
+        )
+        if restart_url and restart_url != request.build_absolute_uri():
+            return redirect(restart_url)
         return _collaborative_access_closed_response(
             request,
             project,
             document_label,
             "This collaborative session has expired. Ask the authors to resend the link.",
-        )
-
-    external_access = _resolve_external_collaborative_access(
-        request, project, document_type, session
-    )
-    if not user_can_edit and not external_access.get("allowed"):
-        return _collaborative_access_closed_response(
-            request,
-            project,
-            document_label,
-            external_access.get("message")
-            or "You do not have access to this collaborative session.",
         )
 
     document = _get_document_for_type(project, document_type)
@@ -4703,6 +4725,11 @@ def collaborative_edit(request, project_id, document_slug, token):
                 return redirect(restart_url)
             messages.info(request, "This collaborative session is no longer active.")
             return redirect(detail_url)
+        restart_url = _restart_external_collaborative_url(
+            request, project, document_type, external_access
+        )
+        if restart_url and restart_url != request.build_absolute_uri():
+            return redirect(restart_url)
         return _collaborative_access_closed_response(
             request,
             project,

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1445,6 +1445,7 @@ def _resolve_external_collaborative_access(request, project, document_type, sess
                 "allowed": True,
                 "member": member,
                 "feedback": feedback,
+                "editor_access_mode": "comment",
                 "participant_display": display,
                 "participant_context": {
                     "id": f"abm:{member.id}",
@@ -1458,6 +1459,7 @@ def _resolve_external_collaborative_access(request, project, document_type, sess
             "allowed": True,
             "member": None,
             "feedback": feedback,
+            "editor_access_mode": "comment",
             "participant_display": display,
             "participant_context": {
                 "id": f"abe:{display.lower()}",
@@ -1525,6 +1527,7 @@ def _resolve_external_collaborative_access(request, project, document_type, sess
             "allowed": True,
             "member": member,
             "invitation": invitation,
+            "editor_access_mode": "comment",
             "participant_display": display,
             "participant_context": {
                 "id": participant_id,
@@ -1608,6 +1611,7 @@ def _build_onlyoffice_config(
     session,
     document_type,
     participant=None,
+    access_mode="edit",
 ):
     document_file = getattr(document, "document", None)
     if not document_file:
@@ -1640,6 +1644,8 @@ def _build_onlyoffice_config(
         )
     )
 
+    comment_only = access_mode == "comment"
+
     config = {
         "document": {
             "fileType": file_type,
@@ -1647,10 +1653,11 @@ def _build_onlyoffice_config(
             "title": title,
             "url": file_url,
             "permissions": {
-                "edit": True,
+                "edit": not comment_only,
+                "comment": True,
                 "download": True,
                 "print": True,
-                "review": True,
+                "review": not comment_only,
             },
         },
         "editorConfig": {
@@ -1666,6 +1673,10 @@ def _build_onlyoffice_config(
             },
         },
     }
+
+    if comment_only:
+        config["document"]["permissions"]["editCommentAuthorOnly"] = True
+        config["document"]["permissions"]["deleteCommentAuthorOnly"] = True
 
     if user_email:
         config["editorConfig"]["user"]["email"] = user_email
@@ -4757,11 +4768,13 @@ def collaborative_edit(request, project_id, document_slug, token):
     participant_feedback = None
     participant_display = ""
     participant_context = None
+    editor_access_mode = "edit"
     if external_access.get("allowed"):
         participant_member = external_access.get("member")
         participant_feedback = external_access.get("feedback")
         participant_display = external_access.get("participant_display", "")
         participant_context = external_access.get("participant_context")
+        editor_access_mode = external_access.get("editor_access_mode", "comment")
 
     if not participant_member and not participant_context and user_can_edit:
         member_id = request.GET.get("member")
@@ -4796,6 +4809,7 @@ def collaborative_edit(request, project_id, document_slug, token):
             session,
             document_type,
             participant=participant_context,
+            access_mode=editor_access_mode,
         )
     except ValueError as exc:
         if user_can_edit:
@@ -4842,6 +4856,7 @@ def collaborative_edit(request, project_id, document_slug, token):
             "force_end_url": force_end_url,
             "leave_url": leave_url,
             "participant_display": participant_display,
+            "editor_comment_only": editor_access_mode == "comment",
         },
     )
 

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1822,19 +1822,11 @@ def _onlyoffice_command_headers(payload: dict) -> dict[str, str]:
     return headers
 
 
-def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[str, str]:
+def _onlyoffice_command_request(payload: dict) -> tuple[dict | None, str]:
     command_url = _onlyoffice_command_url()
     if not command_url:
-        logger.warning(
-            "OnlyOffice force-save skipped for session %s because command URL is missing",
-            session.pk,
-        )
-        return "failed", "Collaborative save is not configured correctly."
+        return None, "OnlyOffice command service is not configured."
 
-    payload = {
-        "c": "forcesave",
-        "key": _collaborative_document_key(project, document_type, session),
-    }
     timeout = ONLYOFFICE_SETTINGS.get("callback_timeout", 10)
     try:
         response = requests.post(
@@ -1846,10 +1838,24 @@ def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[str,
         response.raise_for_status()
         data = response.json()
     except (requests.RequestException, ValueError) as exc:
+        logger.error("OnlyOffice command request failed: %s", exc)
+        return None, "Unable to contact OnlyOffice."
+    if not isinstance(data, dict):
+        return None, "OnlyOffice returned an unexpected response."
+    return data, ""
+
+
+def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[str, str]:
+    payload = {
+        "c": "forcesave",
+        "key": _collaborative_document_key(project, document_type, session),
+    }
+    data, error_message = _onlyoffice_command_request(payload)
+    if data is None:
         logger.error(
             "OnlyOffice force-save request failed for session %s: %s",
             session.pk,
-            exc,
+            error_message,
         )
         return "failed", "Unable to request a final save from OnlyOffice."
 
@@ -1872,6 +1878,70 @@ def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[str,
             data,
         )
         return "failed", "OnlyOffice did not accept the final save request."
+
+
+def _resolve_collaborative_participant_name(participant_id, *, users_by_id, members_by_id):
+    raw_id = str(participant_id or "").strip()
+    if not raw_id:
+        return ""
+    if raw_id.startswith("abm:"):
+        member = members_by_id.get(raw_id.split(":", 1)[1])
+        return _advisory_member_display(member) if member else raw_id
+    if raw_id.startswith("abe:"):
+        return raw_id.split(":", 1)[1]
+    user = users_by_id.get(raw_id)
+    if user:
+        return _user_display(user)
+    return raw_id
+
+
+def _collaborative_active_participant_names(project, document_type, session) -> list[str]:
+    payload = {
+        "c": "info",
+        "key": _collaborative_document_key(project, document_type, session),
+    }
+    data, error_message = _onlyoffice_command_request(payload)
+    if data is None:
+        logger.info(
+            "OnlyOffice session info unavailable for session %s: %s",
+            session.pk,
+            error_message,
+        )
+        return []
+
+    raw_users = data.get("users") or []
+    if not isinstance(raw_users, list):
+        return []
+
+    participant_ids = [
+        str(user_id).strip() for user_id in raw_users if str(user_id).strip()
+    ]
+    if not participant_ids:
+        return []
+
+    user_ids = [pid for pid in participant_ids if pid.isdigit()]
+    member_ids = [
+        pid.split(":", 1)[1]
+        for pid in participant_ids
+        if pid.startswith("abm:") and pid.split(":", 1)[1].isdigit()
+    ]
+
+    users_by_id = {str(user.pk): user for user in User.objects.filter(pk__in=user_ids)}
+    members_by_id = {
+        str(member.pk): member
+        for member in AdvisoryBoardMember.objects.filter(project=project, pk__in=member_ids)
+    }
+
+    names: list[str] = []
+    for participant_id in participant_ids:
+        name = _resolve_collaborative_participant_name(
+            participant_id,
+            users_by_id=users_by_id,
+            members_by_id=members_by_id,
+        )
+        if name and name not in names:
+            names.append(name)
+    return names
 
 
 def _wait_for_collaborative_save(session, document_type, timeout_seconds: int) -> bool:
@@ -4770,6 +4840,7 @@ def collaborative_edit(request, project_id, document_slug, token):
     participant_context = None
     editor_access_mode = "edit"
     review_deadline_display = ""
+    reviewer_tab_lock_key = ""
     if external_access.get("allowed"):
         participant_member = external_access.get("member")
         participant_feedback = external_access.get("feedback")
@@ -4782,6 +4853,13 @@ def collaborative_edit(request, project_id, document_slug, token):
             ) or getattr(participant_feedback, "feedback_deadline_at", None)
             if review_deadline:
                 review_deadline_display = _format_deadline(review_deadline)
+            participant_lock_id = (
+                participant_context.get("id", "") if participant_context else ""
+            )
+            if participant_lock_id:
+                reviewer_tab_lock_key = (
+                    f"ce-review-tab-{project.id}-{document_type}-{participant_lock_id}"
+                )
 
     if not participant_member and not participant_context and user_can_edit:
         member_id = request.GET.get("member")
@@ -4848,6 +4926,16 @@ def collaborative_edit(request, project_id, document_slug, token):
         + _collaborative_query_suffix(request.GET)
     )
     can_force_end = _user_can_force_end_session(request.user, project, session)
+    active_participant_names = []
+    collaborative_presence_url = ""
+    if user_can_edit:
+        active_participant_names = _collaborative_active_participant_names(
+            project, document_type, session
+        )
+        collaborative_presence_url = reverse(
+            "synopsis:collaborative_presence",
+            args=[project.id, _document_type_slug(document_type), session.token],
+        )
 
     return render(
         request,
@@ -4865,6 +4953,9 @@ def collaborative_edit(request, project_id, document_slug, token):
             "participant_display": participant_display,
             "editor_comment_only": editor_access_mode == "comment",
             "review_deadline_display": review_deadline_display,
+            "reviewer_tab_lock_key": reviewer_tab_lock_key,
+            "active_participant_names": active_participant_names,
+            "collaborative_presence_url": collaborative_presence_url,
         },
     )
 
@@ -4942,9 +5033,26 @@ def collaborative_leave(request, project_id, document_slug, token):
             "participant_display": participant_display,
             "editor_comment_only": reviewer_comment_only,
             "review_deadline_display": review_deadline_display,
+            "reviewer_tab_lock_key": "",
         },
         status=200,
     )
+
+
+@login_required
+def collaborative_presence(request, project_id, document_slug, token):
+    project = get_object_or_404(Project, pk=project_id)
+    document_type = _normalize_document_type(document_slug)
+    if not document_type:
+        raise Http404("Unknown document type")
+    if not _user_can_edit_project(request.user, project):
+        return JsonResponse({"detail": "Forbidden"}, status=403)
+
+    session = _collaborative_session_or_404(project, document_type, token)
+    names = []
+    if session.is_active and not session.has_expired():
+        names = _collaborative_active_participant_names(project, document_type, session)
+    return JsonResponse({"participants": names})
 
 
 @login_required

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1581,6 +1581,11 @@ def _collaborative_document_key(project, document_type, session) -> str:
     ]
 
 
+def _collaborative_query_suffix(querydict) -> str:
+    query_string = querydict.urlencode()
+    return f"?{query_string}" if query_string else ""
+
+
 def _build_onlyoffice_config(
     request,
     project,
@@ -4787,6 +4792,13 @@ def collaborative_edit(request, project_id, document_slug, token):
         "synopsis:collaborative_force_end",
         args=[project.id, _document_type_slug(document_type), session.token],
     )
+    leave_url = (
+        reverse(
+            "synopsis:collaborative_leave",
+            args=[project.id, _document_type_slug(document_type), session.token],
+        )
+        + _collaborative_query_suffix(request.GET)
+    )
     can_force_end = _user_can_force_end_session(request.user, project, session)
 
     return render(
@@ -4801,8 +4813,71 @@ def collaborative_edit(request, project_id, document_slug, token):
             "detail_url": project_editor_detail_url,
             "can_force_end": can_force_end,
             "force_end_url": force_end_url,
+            "leave_url": leave_url,
             "participant_display": participant_display,
         },
+    )
+
+
+def collaborative_leave(request, project_id, document_slug, token):
+    project = get_object_or_404(Project, pk=project_id)
+    document_type = _normalize_document_type(document_slug)
+    if not document_type:
+        raise Http404("Unknown document type")
+
+    document_label = _document_label(document_type)
+    detail_url = _document_detail_url(project.id, document_type)
+    user_can_edit = _user_can_edit_project(request.user, project)
+    project_editor_detail_url = detail_url if user_can_edit else ""
+    session = _collaborative_session_or_404(project, document_type, token)
+    external_access = _resolve_external_collaborative_access(
+        request, project, document_type, session
+    )
+    if not user_can_edit and not external_access.get("allowed"):
+        return _collaborative_access_closed_response(
+            request,
+            project,
+            document_label,
+            external_access.get("message")
+            or "You do not have access to this collaborative session.",
+        )
+
+    if user_can_edit:
+        messages.info(
+            request,
+            "You left the collaborative editor. The shared session is still open for other participants.",
+        )
+        return redirect(detail_url)
+
+    reopen_url = ""
+    document = _get_document_for_type(project, document_type)
+    if (
+        session.is_active
+        and not session.has_expired()
+        and not getattr(document, "feedback_closed_at", None)
+    ):
+        reopen_url = reverse(
+            "synopsis:collaborative_edit",
+            args=[project.id, _document_type_slug(document_type), session.token],
+        ) + _collaborative_query_suffix(request.GET)
+
+    return render(
+        request,
+        "synopsis/collaborative_editor.html",
+        {
+            "project": project,
+            "document_label": document_label,
+            "detail_url": project_editor_detail_url,
+            "leave_message": (
+                "You left the collaborative editor. This did not close the shared session for other participants."
+            ),
+            "reopen_url": reopen_url,
+            "can_force_end": False,
+            "force_end_url": "",
+            "leave_url": "",
+            "participant_display": "",
+        },
+        status=200,
     )
 
 

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -4902,6 +4902,14 @@ def collaborative_leave(request, project_id, document_slug, token):
     reopen_url = ""
     document = _get_document_for_type(project, document_type)
     reviewer_comment_only = external_access.get("editor_access_mode") == "comment"
+    participant_display = external_access.get("participant_display", "")
+    review_deadline_display = ""
+    if reviewer_comment_only:
+        review_deadline = _member_feedback_deadline(
+            external_access.get("member"), document_type
+        ) or getattr(external_access.get("feedback"), "feedback_deadline_at", None)
+        if review_deadline:
+            review_deadline_display = _format_deadline(review_deadline)
     if (
         session.is_active
         and not session.has_expired()
@@ -4931,7 +4939,9 @@ def collaborative_leave(request, project_id, document_slug, token):
             "can_force_end": False,
             "force_end_url": "",
             "leave_url": "",
-            "participant_display": "",
+            "participant_display": participant_display,
+            "editor_comment_only": reviewer_comment_only,
+            "review_deadline_display": review_deadline_display,
         },
         status=200,
     )

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1824,8 +1824,9 @@ def _onlyoffice_command_headers(payload: dict) -> dict[str, str]:
 
 def _onlyoffice_command_request(payload: dict) -> tuple[dict | None, str]:
     command_url = _onlyoffice_command_url()
+    command_name = payload.get("c") or "unknown"
     if not command_url:
-        return None, "OnlyOffice command service is not configured."
+        return None, f"OnlyOffice command '{command_name}' is not configured."
 
     timeout = ONLYOFFICE_SETTINGS.get("callback_timeout", 10)
     try:
@@ -1837,11 +1838,10 @@ def _onlyoffice_command_request(payload: dict) -> tuple[dict | None, str]:
         )
         response.raise_for_status()
         data = response.json()
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("OnlyOffice command request failed: %s", exc)
-        return None, "Unable to contact OnlyOffice."
+    except (requests.RequestException, ValueError):
+        return None, f"OnlyOffice command '{command_name}' could not be completed."
     if not isinstance(data, dict):
-        return None, "OnlyOffice returned an unexpected response."
+        return None, f"OnlyOffice command '{command_name}' returned an unexpected response."
     return data, ""
 
 

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -4973,10 +4973,17 @@ def collaborative_leave(request, project_id, document_slug, token):
     user_can_edit = _user_can_edit_project(request.user, project)
     project_editor_detail_url = detail_url if user_can_edit else ""
     session = _collaborative_session_or_404(project, document_type, token)
+    if user_can_edit:
+        messages.info(
+            request,
+            "You left the collaborative editor. The shared session is still open for other participants.",
+        )
+        return redirect(detail_url)
+
     external_access = _resolve_external_collaborative_access(
         request, project, document_type, session
     )
-    if not user_can_edit and not external_access.get("allowed"):
+    if not external_access.get("allowed"):
         return _collaborative_access_closed_response(
             request,
             project,
@@ -4984,13 +4991,6 @@ def collaborative_leave(request, project_id, document_slug, token):
             external_access.get("message")
             or "You do not have access to this collaborative session.",
         )
-
-    if user_can_edit:
-        messages.info(
-            request,
-            "You left the collaborative editor. The shared session is still open for other participants.",
-        )
-        return redirect(detail_url)
 
     reopen_url = ""
     document = _get_document_for_type(project, document_type)

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -1879,6 +1879,8 @@ def _request_onlyoffice_forcesave(project, document_type, session) -> tuple[str,
         )
         return "failed", "OnlyOffice did not accept the final save request."
 
+    return "failed", "OnlyOffice did not accept the final save request."
+
 
 def _resolve_collaborative_participant_name(participant_id, *, users_by_id, members_by_id):
     raw_id = str(participant_id or "").strip()

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -26,6 +26,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User, Group
 from django.contrib.auth.tokens import default_token_generator
+from django.core.cache import cache
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.files.base import ContentFile
 from django.core.mail import EmailMultiAlternatives
@@ -1943,6 +1944,18 @@ def _collaborative_active_participant_names(project, document_type, session) -> 
         )
         if name and name not in names:
             names.append(name)
+    return names
+
+
+def _collaborative_active_participant_names_cached(
+    project, document_type, session, *, ttl_seconds=10
+) -> list[str]:
+    cache_key = f"collab-presence:{session.id}:{document_type}"
+    cached_names = cache.get(cache_key)
+    if isinstance(cached_names, list):
+        return cached_names
+    names = _collaborative_active_participant_names(project, document_type, session)
+    cache.set(cache_key, names, ttl_seconds)
     return names
 
 
@@ -4931,7 +4944,7 @@ def collaborative_edit(request, project_id, document_slug, token):
     active_participant_names = []
     collaborative_presence_url = ""
     if user_can_edit:
-        active_participant_names = _collaborative_active_participant_names(
+        active_participant_names = _collaborative_active_participant_names_cached(
             project, document_type, session
         )
         collaborative_presence_url = reverse(
@@ -5053,7 +5066,9 @@ def collaborative_presence(request, project_id, document_slug, token):
     session = _collaborative_session_or_404(project, document_type, token)
     names = []
     if session.is_active and not session.has_expired():
-        names = _collaborative_active_participant_names(project, document_type, session)
+        names = _collaborative_active_participant_names_cached(
+            project, document_type, session
+        )
     return JsonResponse({"participants": names})
 
 

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -114,6 +114,21 @@
     gap: 0.5rem;
   }
 
+  .collab-review-summary {
+    margin-top: 0.5rem;
+    color: #475569;
+    font-size: 0.92rem;
+    line-height: 1.4;
+  }
+
+  .collab-save-status {
+    font-weight: 600;
+  }
+
+  .collab-save-status.is-saved {
+    color: #166534;
+  }
+
   .collab-review-guide {
     margin-top: 0.75rem;
     padding-top: 0.75rem;
@@ -221,6 +236,12 @@
                         <a class="collab-link" href="{{ detail_url }}">Back to {{ document_label|lower }} detail</a>
                         {% endif %}
                     </div>
+                    {% if editor_comment_only %}
+                    <div class="collab-review-summary">
+                        To comment, highlight text and use the comment button in the toolbar. Authors will review your comments and decide whether to apply them.
+                        <span id="collab-save-status" class="collab-save-status">Comments save automatically while you work.</span>
+                    </div>
+                    {% endif %}
                 </div>
                 <div class="collab-header-actions">
                     <div class="collab-header-status">
@@ -232,11 +253,14 @@
                         {% if editor_comment_only %}
                         <span class="collab-pill collab-pill-strong">Comment-only access</span>
                         {% endif %}
+                        {% if review_deadline_display %}
+                        <span class="collab-pill">Comments accepted until <strong>{{ review_deadline_display }}</strong></span>
+                        {% endif %}
                     </div>
                     {% if leave_url %}
-                    <a class="btn btn-primary btn-sm" href="{{ leave_url }}">Leave editor</a>
+                    <a class="btn btn-primary btn-sm" href="{{ leave_url }}">{% if editor_comment_only %}Leave review page{% else %}Leave editor{% endif %}</a>
                     {% elif detail_url %}
-                    <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Leave editor</a>
+                    <a class="btn btn-primary btn-sm" href="{{ detail_url }}">{% if editor_comment_only %}Leave review page{% else %}Leave editor{% endif %}</a>
                     {% endif %}
                 </div>
             </div>
@@ -275,7 +299,7 @@
 </div>
 <div class="mx-3 mx-md-4 mb-3 d-flex flex-wrap gap-2">
     {% if reopen_url %}
-    <a class="btn btn-outline-primary btn-sm" href="{{ reopen_url }}">Reopen editor</a>
+    <a class="btn btn-outline-primary btn-sm" href="{{ reopen_url }}">{{ reopen_label|default:"Reopen editor" }}</a>
     {% endif %}
     {% if detail_url %}
     <a class="btn btn-outline-secondary btn-sm" href="{{ detail_url }}">Back to {{ document_label|lower }} detail</a>
@@ -337,6 +361,22 @@
             container.style.height = `${height}px`;
             config.width = '100%';
             config.height = `${height}px`;
+            {% if editor_comment_only %}
+            const saveStatus = document.getElementById('collab-save-status');
+            const setSaveStatus = function(message, isSaved) {
+                if (!saveStatus) return;
+                saveStatus.textContent = message;
+                saveStatus.classList.toggle('is-saved', Boolean(isSaved));
+            };
+            config.events = config.events || {};
+            config.events.onDocumentStateChange = function(event) {
+                if (event && event.data) {
+                    setSaveStatus('Saving comments...', false);
+                } else {
+                    setSaveStatus('Comments saved.', true);
+                }
+            };
+            {% endif %}
             window.docEditor = new DocsAPI.DocEditor('onlyoffice-editor', config);
         }
 

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -11,32 +11,258 @@
 {# TODO: #58 Add document version history or snapshots that collaborators can inspect and restore. #}
 {# TODO: #59 Support inline document comments, either through OnlyOffice features or a portal-side comment layer. #}
 {# TODO: #60 Show who is currently viewing or editing the document in real time. #}
+<style>
+  .collab-top {
+    background: linear-gradient(180deg, #f7f9fc 0%, #ffffff 100%);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  }
 
-<div class="collab-header py-3 px-3 px-md-4">
-    <h1 class="mb-2">Collaborative editor – {{ document_label }}</h1>
-    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
-        <div>
-            <div class="fw-semibold">{{ project.title }}</div>
-            {% if detail_url %}
-            <a class="small" href="{{ detail_url }}">Back to {{ document_label|lower }} detail</a>
-            {% endif %}
-        </div>
-        <div class="d-flex flex-wrap align-items-center gap-2">
-            {% if leave_url %}
-            <a class="btn btn-primary btn-sm" href="{{ leave_url }}">Leave editor</a>
-            {% elif detail_url %}
-            <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Leave editor</a>
+  .collab-header-card {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 1rem;
+    background: #ffffff;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+    padding: 1rem 1.1rem;
+  }
+
+  .collab-header-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .collab-kicker {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #5b6b7f;
+    margin-bottom: 0.35rem;
+  }
+
+  .collab-title {
+    font-size: 1.45rem;
+    line-height: 1.15;
+    margin: 0;
+  }
+
+  .collab-title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .collab-project-inline {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #475569;
+  }
+
+  .collab-project {
+    font-weight: 600;
+    color: #1f2937;
+    margin-top: 0.3rem;
+  }
+
+  .collab-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.65rem;
+  }
+
+  .collab-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: #eef3f8;
+    color: #334155;
+    font-size: 0.9rem;
+  }
+
+  .collab-pill-strong {
+    background: #e7f1ff;
+    color: #0b4a8b;
+  }
+
+  .collab-link {
+    font-size: 0.95rem;
+    text-decoration: none;
+  }
+
+  .collab-link:hover {
+    text-decoration: underline;
+  }
+
+  .collab-header-actions {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+
+  .collab-header-status {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .collab-review-guide {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+  }
+
+  .collab-review-guide summary {
+    cursor: pointer;
+    font-weight: 700;
+    color: #0f172a;
+    list-style: none;
+  }
+
+  .collab-review-guide summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .collab-review-guide-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 0.8rem;
+    background: #f8fafc;
+    padding: 0.7rem 0.9rem;
+  }
+
+  .collab-review-guide-summary small {
+    color: #5b6b7f;
+    font-weight: 500;
+  }
+
+  .collab-review-guide-body {
+    margin-top: 0.65rem;
+    padding: 0 0.15rem;
+  }
+
+  .collab-review-guide-body ul {
+    margin: 0;
+    padding-left: 1.1rem;
+  }
+
+  .collab-review-guide-body li {
+    margin-bottom: 0.35rem;
+    color: #475569;
+    font-size: 0.92rem;
+    line-height: 1.4;
+  }
+
+  #onlyoffice-editor {
+    width: 100%;
+    min-height: 420px;
+    height: 100%;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  @media (max-width: 900px) {
+    .collab-header-main {
+      grid-template-columns: 1fr;
+    }
+
+    .collab-header-actions {
+      justify-content: flex-start;
+      align-items: flex-start;
+    }
+
+    .collab-header-status {
+      justify-content: flex-start;
+    }
+  }
+
+  @media (max-width: 768px) {
+    #onlyoffice-editor {
+      min-height: 360px;
+    }
+
+    .collab-header-card {
+      padding: 0.9rem;
+      border-radius: 0.85rem;
+    }
+
+    .collab-title {
+      font-size: 1.25rem;
+    }
+  }
+</style>
+
+<div class="collab-top">
+    <div class="collab-header py-3 px-3 px-md-4">
+        <div class="collab-header-card">
+            <div class="collab-header-main">
+                <div>
+                    <div class="collab-kicker">
+                        {% if editor_comment_only %}Advisory board review workspace{% else %}Collaborative editing workspace{% endif %}
+                    </div>
+                    <div class="collab-title-row">
+                        <h1 class="collab-title">{{ document_label }} editor</h1>
+                        <span class="collab-project-inline">{{ project.title }}</span>
+                    </div>
+                    <div class="collab-meta">
+                        {% if detail_url %}
+                        <a class="collab-link" href="{{ detail_url }}">Back to {{ document_label|lower }} detail</a>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="collab-header-actions">
+                    <div class="collab-header-status">
+                        {% if participant_display %}
+                        <span class="collab-pill">
+                            You are signed in as <strong>{{ participant_display }}</strong>
+                        </span>
+                        {% endif %}
+                        {% if editor_comment_only %}
+                        <span class="collab-pill collab-pill-strong">Comment-only access</span>
+                        {% endif %}
+                    </div>
+                    {% if leave_url %}
+                    <a class="btn btn-primary btn-sm" href="{{ leave_url }}">Leave editor</a>
+                    {% elif detail_url %}
+                    <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Leave editor</a>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% if editor_config and editor_comment_only and participant_display %}
+            <details class="collab-review-guide">
+                <summary class="collab-review-guide-summary">
+                    <span>How to review this document</span>
+                    <small>Open instructions</small>
+                </summary>
+                <div class="collab-review-guide-body">
+                    <ul>
+                        <li>Advisory board feedback is collected as comments so the authors can review each suggestion and decide what to change.</li>
+                        <li>Highlight the relevant text and use the comment button in the editor toolbar, or right-click the highlighted text and choose the comment option.</li>
+                        <li>Place the cursor near the relevant section first, then add the comment from the toolbar so the authors can see what part of the document it refers to.</li>
+                        <li>Use <strong>Leave editor</strong>. This does not close the shared session for anyone else, and you can reopen the same link later while the feedback window is still open.</li>
+                    </ul>
+                </div>
+            </details>
+            {% elif can_force_end and detail_url %}
+            <div class="small text-muted mt-3">
+                To save and close the shared session for everyone, return to the {{ document_label|lower }} detail page.
+            </div>
             {% endif %}
         </div>
     </div>
-    {% if participant_display %}
-    <div class="small text-muted mt-2">You are editing as {{ participant_display }}.</div>
-    {% endif %}
-    {% if can_force_end and detail_url %}
-    <div class="small text-muted mt-2">
-        To save and close the shared session for everyone, return to the {{ document_label|lower }} detail page.
-    </div>
-    {% endif %}
 </div>
 {% if window_closed_message %}
 <div class="alert alert-warning mx-3 mx-md-4 mt-3" role="alert">
@@ -58,33 +284,6 @@
     {% endif %}
 </div>
 {% endif %}
-{% if editor_config and not detail_url and participant_display %}
-<div class="alert alert-info mx-3 mx-md-4 mt-3 mb-0" role="alert">
-    <div class="fw-semibold mb-2">How to use this editor</div>
-    <ul class="mb-0 ps-3">
-        <li>Review and edit the {{ document_label|lower }} directly in this document.</li>
-        <li>Your changes save while you work in the editor.</li>
-        <li>Use <strong>Leave editor</strong> when you are finished. This leaves the page without closing the shared session for anyone else.</li>
-        <li>If you need to continue later, reopen the same link while the feedback window is still open.</li>
-    </ul>
-</div>
-{% endif %}
-<style>
-  #onlyoffice-editor {
-    width: 100%;
-    min-height: 420px;
-    height: 100%;
-    border: 1px solid var(--bs-border-color);
-    border-radius: 0.5rem;
-    overflow: hidden;
-  }
-
-  @media (max-width: 768px) {
-    #onlyoffice-editor {
-      min-height: 360px;
-    }
-  }
-</style>
 {% if editor_config %}
 <div id="onlyoffice-editor"></div>
 {{ editor_config|json_script:"onlyoffice-editor-config" }}

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -281,7 +281,7 @@
                         <li>Advisory board feedback is collected as comments so the authors can review each suggestion and decide what to change.</li>
                         <li>Highlight the relevant text and use the comment button in the editor toolbar, or right-click the highlighted text and choose the comment option.</li>
                         <li>Place the cursor near the relevant section first, then add the comment from the toolbar so the authors can see what part of the document it refers to.</li>
-                        <li>Use <strong>Leave editor</strong>. This does not close the shared session for anyone else, and you can reopen the same link later while the feedback window is still open.</li>
+                        <li>Use <strong>Leave review page</strong>. This does not close the shared session for anyone else, and you can reopen the same link later while the feedback window is still open.</li>
                     </ul>
                 </div>
             </details>

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -506,6 +506,21 @@
                     // Keep the most recent successful presence text if polling fails.
                 });
         };
+
+        const stopPresencePolling = function () {
+            if (presencePollTimer) {
+                window.clearInterval(presencePollTimer);
+                presencePollTimer = null;
+            }
+        };
+
+        const startPresencePolling = function () {
+            if (presencePollTimer || document.hidden) {
+                return;
+            }
+            refreshPresence();
+            presencePollTimer = window.setInterval(refreshPresence, 15000);
+        };
         {% endif %}
 
         function handleResize() {
@@ -520,12 +535,16 @@
             window.addEventListener('resize', handleResize);
             window.addEventListener('load', handleResize);
             {% if collaborative_presence_url %}
-            refreshPresence();
-            presencePollTimer = window.setInterval(refreshPresence, 15000);
-            window.addEventListener('beforeunload', function () {
-                if (presencePollTimer) {
-                    window.clearInterval(presencePollTimer);
+            startPresencePolling();
+            document.addEventListener('visibilitychange', function () {
+                if (document.hidden) {
+                    stopPresencePolling();
+                    return;
                 }
+                startPresencePolling();
+            });
+            window.addEventListener('beforeunload', function () {
+                stopPresencePolling();
             });
             {% endif %}
         } else {

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -121,6 +121,17 @@
     line-height: 1.4;
   }
 
+  .collab-active-participants {
+    margin-top: 0.5rem;
+    color: #475569;
+    font-size: 0.92rem;
+    line-height: 1.4;
+  }
+
+  .collab-active-participants strong {
+    color: #0f172a;
+  }
+
   .collab-save-status {
     font-weight: 600;
   }
@@ -231,11 +242,18 @@
                         <h1 class="collab-title">{{ document_label }} editor</h1>
                         <span class="collab-project-inline">{{ project.title }}</span>
                     </div>
-                    <div class="collab-meta">
-                        {% if detail_url %}
-                        <a class="collab-link" href="{{ detail_url }}">Back to {{ document_label|lower }} detail</a>
-                        {% endif %}
+                    {% if collaborative_presence_url %}
+                    <div class="collab-active-participants">
+                        <strong>Active in this document:</strong>
+                        <span id="collab-active-participants-text">
+                            {% if active_participant_names %}
+                                {{ active_participant_names|join:", " }}
+                            {% else %}
+                                No other reviewers or authors are active right now.
+                            {% endif %}
+                        </span>
                     </div>
+                    {% endif %}
                     {% if editor_comment_only %}
                     <div class="collab-review-summary">
                         To comment, highlight text and use the comment button in the toolbar. Authors will review your comments and decide whether to apply them.
@@ -316,11 +334,19 @@
 {% if editor_config %}
 <div id="onlyoffice-editor"></div>
 {{ editor_config|json_script:"onlyoffice-editor-config" }}
+{% if reviewer_tab_lock_key %}
+{{ reviewer_tab_lock_key|json_script:"reviewer-tab-lock-key" }}
+{% endif %}
 <script src="{{ onlyoffice_js_url }}"></script>
 <script>
     (function() {
         const container = document.getElementById('onlyoffice-editor');
         const errorMessage = `<div class="p-4 text-danger">Unable to load the OnlyOffice editor. Check your OnlyOffice configuration.</div>`;
+        const duplicateTabMessage = `
+            <div class="alert alert-warning mx-3 mx-md-4 mt-3" role="alert">
+                This review page is already open in another tab. Return to that tab or close it before opening another one.
+            </div>
+        `;
         if (!container) {
             console.error('OnlyOffice editor container is missing.');
             return;
@@ -343,6 +369,71 @@
         }
 
         const MIN_HEIGHT = 420;
+        let reviewTabLockRelease = null;
+
+        const establishReviewerTabLock = function () {
+            {% if reviewer_tab_lock_key %}
+            const lockSource = document.getElementById('reviewer-tab-lock-key');
+            const resolvedLockKey = lockSource ? JSON.parse(lockSource.textContent) : '';
+            if (!resolvedLockKey) {
+                return true;
+            }
+            const tabId = 'tab-' + Math.random().toString(36).slice(2);
+            const heartbeatMs = 5000;
+            const staleAfterMs = 15000;
+
+            const readLock = function () {
+                try {
+                    const raw = window.localStorage.getItem(resolvedLockKey);
+                    return raw ? JSON.parse(raw) : null;
+                } catch (error) {
+                    return null;
+                }
+            };
+
+            const writeLock = function () {
+                try {
+                    window.localStorage.setItem(
+                        resolvedLockKey,
+                        JSON.stringify({ tabId: tabId, ts: Date.now() })
+                    );
+                    return true;
+                } catch (error) {
+                    return true;
+                }
+            };
+
+            const existing = readLock();
+            if (existing && existing.tabId !== tabId && (Date.now() - (existing.ts || 0)) < staleAfterMs) {
+                container.style.display = 'none';
+                container.insertAdjacentHTML('beforebegin', duplicateTabMessage);
+                return false;
+            }
+
+            writeLock();
+            const heartbeat = window.setInterval(writeLock, heartbeatMs);
+            reviewTabLockRelease = function () {
+                window.clearInterval(heartbeat);
+                const latest = readLock();
+                if (latest && latest.tabId === tabId) {
+                    try {
+                        window.localStorage.removeItem(resolvedLockKey);
+                    } catch (error) {
+                        // ignore
+                    }
+                }
+            };
+
+            window.addEventListener('beforeunload', function () {
+                if (reviewTabLockRelease) {
+                    reviewTabLockRelease();
+                }
+            });
+            return true;
+            {% else %}
+            return true;
+            {% endif %}
+        };
 
         function calculateEditorHeight() {
             const viewportHeight = window.innerHeight || document.documentElement.clientHeight || MIN_HEIGHT;
@@ -385,14 +476,58 @@
             window.docEditor = new DocsAPI.DocEditor('onlyoffice-editor', config);
         }
 
+        {% if collaborative_presence_url %}
+        const participantsText = document.getElementById('collab-active-participants-text');
+        let presencePollTimer = null;
+        const renderParticipants = function (participants) {
+            if (!participantsText) return;
+            if (Array.isArray(participants) && participants.length) {
+                participantsText.textContent = participants.join(', ');
+                return;
+            }
+            participantsText.textContent = 'No other reviewers or authors are active right now.';
+        };
+
+        const refreshPresence = function () {
+            fetch('{{ collaborative_presence_url }}', {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                credentials: 'same-origin'
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Presence request failed');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    renderParticipants(data.participants || []);
+                })
+                .catch(function () {
+                    // Keep the most recent successful presence text if polling fails.
+                });
+        };
+        {% endif %}
+
         function handleResize() {
             applyHeight(calculateEditorHeight());
         }
 
         if (window.DocsAPI && window.DocsAPI.DocEditor) {
+            if (!establishReviewerTabLock()) {
+                return;
+            }
             initialiseEditor();
             window.addEventListener('resize', handleResize);
             window.addEventListener('load', handleResize);
+            {% if collaborative_presence_url %}
+            refreshPresence();
+            presencePollTimer = window.setInterval(refreshPresence, 15000);
+            window.addEventListener('beforeunload', function () {
+                if (presencePollTimer) {
+                    window.clearInterval(presencePollTimer);
+                }
+            });
+            {% endif %}
         } else {
             console.error('OnlyOffice DocsAPI is not available.');
             container.innerHTML = errorMessage;

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -27,14 +27,6 @@
             {% elif detail_url %}
             <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Leave editor</a>
             {% endif %}
-            <button
-                type="button"
-                class="btn btn-outline-secondary btn-sm"
-                data-bs-toggle="modal"
-                data-bs-target="#{{ document_label|slugify }}-editor-workflow-help"
-            >
-                How collaborative editing works
-            </button>
         </div>
     </div>
     {% if participant_display %}
@@ -46,7 +38,6 @@
     </div>
     {% endif %}
 </div>
-{% include "synopsis/includes/collaborative_workflow_modal.html" with workflow_help_slug=document_label|slugify|add:"-editor" %}
 {% if window_closed_message %}
 <div class="alert alert-warning mx-3 mx-md-4 mt-3" role="alert">
     {{ window_closed_message }}
@@ -65,6 +56,17 @@
     {% else %}
     <button type="button" class="btn btn-outline-secondary btn-sm" onclick="window.close()">Close this tab</button>
     {% endif %}
+</div>
+{% endif %}
+{% if editor_config and not detail_url and participant_display %}
+<div class="alert alert-info mx-3 mx-md-4 mt-3 mb-0" role="alert">
+    <div class="fw-semibold mb-2">How to use this editor</div>
+    <ul class="mb-0 ps-3">
+        <li>Review and edit the {{ document_label|lower }} directly in this document.</li>
+        <li>Your changes save while you work in the editor.</li>
+        <li>Use <strong>Leave editor</strong> when you are finished. This leaves the page without closing the shared session for anyone else.</li>
+        <li>If you need to continue later, reopen the same link while the feedback window is still open.</li>
+    </ul>
 </div>
 {% endif %}
 <style>

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -22,6 +22,11 @@
             {% endif %}
         </div>
         <div class="d-flex flex-wrap align-items-center gap-2">
+            {% if leave_url %}
+            <a class="btn btn-primary btn-sm" href="{{ leave_url }}">Leave editor</a>
+            {% elif detail_url %}
+            <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Leave editor</a>
+            {% endif %}
             <button
                 type="button"
                 class="btn btn-outline-secondary btn-sm"
@@ -30,27 +35,36 @@
             >
                 How collaborative editing works
             </button>
-            {% if can_force_end %}
-            <form
-                method="post"
-                action="{{ force_end_url }}"
-                class="d-inline"
-                onsubmit="return confirm('Request a final save and end this collaborative session for everyone?');"
-            >
-                {% csrf_token %}
-                <button type="submit" class="btn btn-outline-danger btn-sm">Save and end session</button>
-            </form>
-            {% endif %}
         </div>
     </div>
     {% if participant_display %}
     <div class="small text-muted mt-2">You are editing as {{ participant_display }}.</div>
+    {% endif %}
+    {% if can_force_end and detail_url %}
+    <div class="small text-muted mt-2">
+        To save and close the shared session for everyone, return to the {{ document_label|lower }} detail page.
+    </div>
     {% endif %}
 </div>
 {% include "synopsis/includes/collaborative_workflow_modal.html" with workflow_help_slug=document_label|slugify|add:"-editor" %}
 {% if window_closed_message %}
 <div class="alert alert-warning mx-3 mx-md-4 mt-3" role="alert">
     {{ window_closed_message }}
+</div>
+{% endif %}
+{% if leave_message %}
+<div class="alert alert-info mx-3 mx-md-4 mt-3" role="alert">
+    {{ leave_message }}
+</div>
+<div class="mx-3 mx-md-4 mb-3 d-flex flex-wrap gap-2">
+    {% if reopen_url %}
+    <a class="btn btn-outline-primary btn-sm" href="{{ reopen_url }}">Reopen editor</a>
+    {% endif %}
+    {% if detail_url %}
+    <a class="btn btn-outline-secondary btn-sm" href="{{ detail_url }}">Back to {{ document_label|lower }} detail</a>
+    {% else %}
+    <button type="button" class="btn btn-outline-secondary btn-sm" onclick="window.close()">Close this tab</button>
+    {% endif %}
 </div>
 {% endif %}
 <style>
@@ -139,7 +153,7 @@
         }
     })();
 </script>
-{% elif not window_closed_message %}
+{% elif not window_closed_message and not leave_message %}
 <div class="p-4 text-muted">
     Collaborative editing is currently unavailable.
 </div>

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -247,7 +247,7 @@
                     <div class="collab-header-status">
                         {% if participant_display %}
                         <span class="collab-pill">
-                            You are signed in as <strong>{{ participant_display }}</strong>
+                            {% if editor_comment_only %}Reviewing as{% else %}You are signed in as{% endif %} <strong>{{ participant_display }}</strong>
                         </span>
                         {% endif %}
                         {% if editor_comment_only %}

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -281,9 +281,9 @@
                         {% endif %}
                     </div>
                     {% if not editor_comment_only and leave_url %}
-                    <a class="btn btn-primary btn-sm" href="{{ leave_url }}">{% if editor_comment_only %}Leave review page{% else %}Leave editor{% endif %}</a>
+                    <a class="btn btn-primary btn-sm" href="{{ leave_url }}">Back to {{ document_label|lower }} page</a>
                     {% elif not editor_comment_only and detail_url %}
-                    <a class="btn btn-primary btn-sm" href="{{ detail_url }}">{% if editor_comment_only %}Leave review page{% else %}Leave editor{% endif %}</a>
+                    <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Back to {{ document_label|lower }} page</a>
                     {% endif %}
                 </div>
             </div>

--- a/src/templates/synopsis/collaborative_editor.html
+++ b/src/templates/synopsis/collaborative_editor.html
@@ -256,10 +256,15 @@
                         {% if review_deadline_display %}
                         <span class="collab-pill">Comments accepted until <strong>{{ review_deadline_display }}</strong></span>
                         {% endif %}
+                        {% if editor_comment_only and leave_url %}
+                        <a class="btn btn-primary btn-sm" href="{{ leave_url }}">Leave review page</a>
+                        {% elif editor_comment_only and detail_url %}
+                        <a class="btn btn-primary btn-sm" href="{{ detail_url }}">Leave review page</a>
+                        {% endif %}
                     </div>
-                    {% if leave_url %}
+                    {% if not editor_comment_only and leave_url %}
                     <a class="btn btn-primary btn-sm" href="{{ leave_url }}">{% if editor_comment_only %}Leave review page{% else %}Leave editor{% endif %}</a>
-                    {% elif detail_url %}
+                    {% elif not editor_comment_only and detail_url %}
                     <a class="btn btn-primary btn-sm" href="{{ detail_url }}">{% if editor_comment_only %}Leave review page{% else %}Leave editor{% endif %}</a>
                     {% endif %}
                 </div>

--- a/src/templates/synopsis/includes/collaborative_panel.html
+++ b/src/templates/synopsis/includes/collaborative_panel.html
@@ -45,14 +45,19 @@
                 method="post"
                 action="{{ collaborative_force_end_url }}"
                 class="d-inline"
-                onsubmit="return confirm('Request a final save and end this collaborative session for everyone?');"
+                onsubmit="return confirm('Request a final save and close this collaborative session for everyone? Use this only when all participants are finished.');"
             >
                 {% csrf_token %}
-                <button type="submit" class="btn btn-outline-danger btn-sm">Save and end session</button>
+                <button type="submit" class="btn btn-outline-danger btn-sm">Save and close session for everyone</button>
             </form>
             {% endif %}
         </div>
     </div>
+    {% if collaborative_can_override and collaborative_force_end_url %}
+    <div class="small text-muted mt-2">
+        Participants can leave the editor without using this button. Use this only when everyone is finished.
+    </div>
+    {% endif %}
     {% else %}
     <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 align-items-start align-items-lg-center">
         <div>

--- a/src/templates/synopsis/includes/collaborative_workflow_modal.html
+++ b/src/templates/synopsis/includes/collaborative_workflow_modal.html
@@ -22,7 +22,8 @@
                     <li>Choose <strong>Start collaborative edit</strong> to open one shared OnlyOffice session for the current {{ document_label|lower }} revision.</li>
                     <li>Authors with edit access reopen the same live session from the portal while it is active, so everyone works in the same document.</li>
                     <li>Use the editor normally while the session is open. The portal keeps that session attached to the current revision on this page.</li>
-                    <li>When edits are complete, use <strong>Save and end session</strong> from the portal. That requests a final save and closes the shared session for everyone.</li>
+                    <li>When one participant is finished, use <strong>Leave editor</strong>. That exits only that participant and does not close the shared session for anyone else.</li>
+                    <li>When all edits are complete, an author or manager can use <strong>Save and close session for everyone</strong> from the {{ document_label|lower }} detail page. That requests a final save and closes the shared session.</li>
                     <li>After the session closes, return to the detail page to download the saved file, keep it in draft, or mark the current revision as final.</li>
                 </ol>
                 <div class="small text-muted">


### PR DESCRIPTION
# Pull Request
<!-- Please fill out the following sections to the best of your ability. You may skip any sections that are not mandatory or relevant by putting 'N/A' inside the sub-section. -->

_Please answer the following sections before submitting your PR:_

## Type of Change
<!-- Mandatory -->
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues
<!-- Mandatory -->

#### 1 Why was this PR needed?
This PR updates the collaborative editor flow to distinguish “leaving” the editor from “closing the session for everyone”, and introduces a comment-only experience for external (advisory) reviewers with improved session restart behavior.

#### 2 What changed?
Changes:

- Updates collaborative session UX copy: “Leave editor” vs “Save and close session for everyone”, and adds explanatory helper text on the detail panel.
- Adds comment-only OnlyOffice permissions for external reviewer access and surfaces review deadline/status in the editor header.
- Adds a dedicated collaborative_leave route/view and enhances external-link behavior to restart into a fresh session when the current one is inactive/expired.

#### 3 Backward compatibility & risk
N/A

#### 4 Files changed
See files changed for full details.

#### 5 Other changes
Minor cosmetic improvements here and there in relation to the PR.

## Testing & Results
<!-- Mandatory -->
All tests passed.

## Checklist
<!-- Mandatory -->
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my changes work
- [x] All new and existing tests pass
- [x] My changes follow the established code style guidelines

## Screenshots (if applicable)
<!-- Optional -->
_Add screenshots here if needed_

## Notes
<!-- Optional -->
e.g. additional information, context, or comments for reviewers.