### PR TITLE
Enhancement reference internal comments

### DIFF
--- a/src/synopsis/forms.py
+++ b/src/synopsis/forms.py
@@ -1003,17 +1003,6 @@ class SynopsisInterventionSynthesisForm(forms.Form):
         widget=forms.Select(attrs={"class": "form-select"}),
         label="Evidence status",
     )
-    synthesis_text = forms.CharField(
-        required=False,
-        widget=forms.Textarea(
-            attrs={
-                "class": "form-control",
-                "rows": 5,
-                "placeholder": "Optional text that should appear after key messages and before study paragraphs.",
-            }
-        ),
-        label="Additional intervention text",
-    )
 
 
 class SynopsisKeyMessageForm(forms.Form):

--- a/src/synopsis/forms.py
+++ b/src/synopsis/forms.py
@@ -2649,6 +2649,22 @@ class ReferenceSummaryParagraphNotesForm(forms.ModelForm):
         self.fields["paragraph_notes"].required = False
         self.fields["paragraph_notes"].help_text = (
             "Internal notes for this paragraph only. Use this to explain wording, numbers, study design calls, or anything future authors should remember. These notes stay in the portal and are not exported in the synopsis."
+        )
+
+    class Meta:
+        model = ReferenceSummary
+        fields = ["paragraph_notes"]
+        widgets = {
+            "paragraph_notes": forms.Textarea(
+                attrs={
+                    "class": "form-control",
+                    "rows": 4,
+                    "placeholder": "Example: Yes, this is 10 species not 11; see Fig. 4. Or: not replicated because only one treatment site was sampled.",
+                }
+            )
+        }
+
+
 class ReferenceActionSummaryForm(forms.ModelForm):
     class Meta:
         model = ReferenceActionSummary

--- a/src/synopsis/forms.py
+++ b/src/synopsis/forms.py
@@ -2643,6 +2643,12 @@ class ReferenceSummaryDraftForm(forms.ModelForm):
         }
 
 
+class ReferenceSummaryParagraphNotesForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["paragraph_notes"].required = False
+        self.fields["paragraph_notes"].help_text = (
+            "Internal notes for this paragraph only. Use this to explain wording, numbers, study design calls, or anything future authors should remember. These notes stay in the portal and are not exported in the synopsis."
 class ReferenceActionSummaryForm(forms.ModelForm):
     class Meta:
         model = ReferenceActionSummary

--- a/src/synopsis/forms.py
+++ b/src/synopsis/forms.py
@@ -987,7 +987,7 @@ class SynopsisBackgroundForm(forms.Form):
     )
 
 
-class SynopsisInterventionSynthesisForm(forms.Form):
+class SynopsisInterventionDetailsForm(forms.Form):
     ce_action_url = forms.URLField(
         required=False,
         widget=forms.URLInput(

--- a/src/synopsis/forms.py
+++ b/src/synopsis/forms.py
@@ -979,10 +979,11 @@ class SynopsisBackgroundForm(forms.Form):
             attrs={
                 "class": "form-control",
                 "rows": 3,
-                "placeholder": "Background references (one per line, published before search end date).",
+                "placeholder": "Background references (one per line, optional contextual sources; not limited by the search end date).",
             }
         ),
         label="Background references",
+        help_text="Optional. Use any relevant contextual references here. They do not need to be published before the search end date.",
     )
 
 

--- a/src/synopsis/migrations/0103_referencesummary_paragraph_notes.py
+++ b/src/synopsis/migrations/0103_referencesummary_paragraph_notes.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="referencesummary",
             name="paragraph_notes",
-            field=models.TextField(blank=True),
+            field=models.TextField(blank=True, default=""),
+            preserve_default=False,
         ),
     ]

--- a/src/synopsis/migrations/0103_referencesummary_paragraph_notes.py
+++ b/src/synopsis/migrations/0103_referencesummary_paragraph_notes.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("synopsis", "0102_referencesummary_use_custom_synopsis_draft"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="referencesummary",
+            name="paragraph_notes",
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/src/synopsis/migrations/0104_remove_synopsisintervention_synthesis_text.py
+++ b/src/synopsis/migrations/0104_remove_synopsisintervention_synthesis_text.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("synopsis", "0103_referencesummary_paragraph_notes"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="synopsisintervention",
+            name="synthesis_text",
+        ),
+    ]

--- a/src/synopsis/models.py
+++ b/src/synopsis/models.py
@@ -1869,7 +1869,6 @@ class SynopsisIntervention(models.Model):
         choices=EVIDENCE_STATUS_CHOICES,
         default=EVIDENCE_STATUS_HAS_EVIDENCE,
     )
-    synthesis_text = models.TextField(blank=True)
     position = models.PositiveIntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/synopsis/models.py
+++ b/src/synopsis/models.py
@@ -1643,6 +1643,7 @@ class ReferenceSummary(models.Model):
     key_findings = models.TextField(blank=True)
     synopsis_draft = models.TextField(blank=True)
     use_custom_synopsis_draft = models.BooleanField(default=False)
+    paragraph_notes = models.TextField(blank=True)
     exclusion_reason = models.TextField(blank=True)
     summary_author = models.CharField(max_length=255, blank=True)
     broad_category = models.CharField(max_length=255, blank=True)

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -8810,11 +8810,12 @@ class ReferenceSummaryDetailViewTests(TestCase):
 
     def test_save_internal_paragraph_notes_persists_and_logs_history(self):
         self.client.login(username="author", password="pass123")
+        url = reverse(
+            "synopsis:reference_summary_detail",
+            args=[self.project.id, self.summary.id],
+        )
         response = self.client.post(
-            reverse(
-                "synopsis:reference_summary_detail",
-                args=[self.project.id, self.summary.id],
-            ),
+            url,
             {
                 "action": "save-paragraph-notes",
                 "paragraph_notes": "Yes, this is 10 species not 11; see Fig. 4.",
@@ -8835,6 +8836,28 @@ class ReferenceSummaryDetailViewTests(TestCase):
         self.assertIsNotNone(change)
         self.assertIn("Reference: Test reference", change.details)
         self.assertIn("Notes: Yes, this is 10 species not 11; see Fig. 4.", change.details)
+
+        response = self.client.post(
+            url,
+            {
+                "action": "save-paragraph-notes",
+                "paragraph_notes": "",
+            },
+            follow=True,
+        )
+
+        self.summary.refresh_from_db()
+        self.assertEqual(self.summary.paragraph_notes, "")
+        self.assertContains(response, "Internal paragraph notes cleared.")
+        cleared_change = ProjectChangeLog.objects.filter(
+            project=self.project,
+            action="Summary paragraph notes cleared",
+        ).first()
+        self.assertIsNotNone(cleared_change)
+        self.assertIn(
+            "Previous notes: Yes, this is 10 species not 11; see Fig. 4.",
+            cleared_change.details,
+        )
 
     def test_detail_status_update_requires_reason_for_summary_phase_exclusion(self):
         self.reference.screening_status = "included"

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -8502,6 +8502,8 @@ class ReferenceSummaryDetailViewTests(TestCase):
         self.assertContains(response, "Save custom paragraph")
         self.assertContains(response, "Switch back to auto-generated")
         self.assertContains(response, "Clear saved custom paragraph")
+        self.assertContains(response, "Internal notes on this paragraph")
+        self.assertContains(response, "Save paragraph notes")
         self.assertContains(response, "Use these tags to organise, filter and group summaries across the synopsis.")
         self.assertContains(response, "Stored separately for internal use. These scores are not inserted into the generated summary paragraph.")
         self.assertContains(response, "Outcome notes")
@@ -8781,6 +8783,34 @@ class ReferenceSummaryDetailViewTests(TestCase):
             "Custom paragraph saved and set as the version used for compilation. Status moved to In progress automatically.",
         )
 
+    def test_save_internal_paragraph_notes_persists_and_logs_history(self):
+        self.client.login(username="author", password="pass123")
+        response = self.client.post(
+            reverse(
+                "synopsis:reference_summary_detail",
+                args=[self.project.id, self.summary.id],
+            ),
+            {
+                "action": "save-paragraph-notes",
+                "paragraph_notes": "Yes, this is 10 species not 11; see Fig. 4.",
+            },
+            follow=True,
+        )
+
+        self.summary.refresh_from_db()
+        self.assertEqual(
+            self.summary.paragraph_notes,
+            "Yes, this is 10 species not 11; see Fig. 4.",
+        )
+        self.assertContains(response, "Internal paragraph notes saved.")
+        change = ProjectChangeLog.objects.filter(
+            project=self.project,
+            action="Summary paragraph notes saved",
+        ).first()
+        self.assertIsNotNone(change)
+        self.assertIn("Reference: Test reference", change.details)
+        self.assertIn("Notes: Yes, this is 10 species not 11; see Fig. 4.", change.details)
+
     def test_detail_status_update_requires_reason_for_summary_phase_exclusion(self):
         self.reference.screening_status = "included"
         self.reference.save(update_fields=["screening_status", "updated_at"])
@@ -8969,6 +8999,7 @@ class ReferenceSummaryDetailViewTests(TestCase):
         self.summary.outcome_rows = [{"outcome": "Occupancy", "notes": "Higher"}]
         self.summary.synopsis_draft = "Draft paragraph copied from the first tab."
         self.summary.use_custom_synopsis_draft = True
+        self.summary.paragraph_notes = "Check whether this was really replicated."
         self.summary.summary_author = "Existing Author"
         self.summary.keywords = ["boxes", "occupancy"]
         self.summary.action_tags = ["Land/water protection-Area protection"]
@@ -9017,6 +9048,10 @@ class ReferenceSummaryDetailViewTests(TestCase):
             "Draft paragraph copied from the first tab.",
         )
         self.assertTrue(new_summary.use_custom_synopsis_draft)
+        self.assertEqual(
+            new_summary.paragraph_notes,
+            "Check whether this was really replicated.",
+        )
         self.assertEqual(new_summary.summary_author, "Existing Author")
         self.assertEqual(new_summary.keywords, ["boxes", "occupancy"])
         self.assertEqual(

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -906,8 +906,8 @@ class SynopsisStructureTests(TestCase):
         self.assertContains(response, "Background")
         self.assertContains(response, "Key messages")
         self.assertContains(response, "Assigned summaries")
-        self.assertContains(response, "Additional intervention text")
-        self.assertContains(response, "Most content should be added as background, key messages or assigned summaries.")
+        self.assertContains(response, "Intervention evidence details")
+        self.assertContains(response, "These fields are kept only as intervention metadata and do not add extra narrative text to the compiled synopsis.")
         self.assertContains(response, "Assigned study summaries to review")
         self.assertContains(response, "review the assigned summaries here first")
         self.assertContains(response, "mowing more frequently increased arable plant richness")
@@ -1015,7 +1015,7 @@ class SynopsisStructureTests(TestCase):
             SynopsisIntervention.objects.filter(subheading__chapter=text_chapter).exists()
         )
 
-    def test_update_intervention_synthesis_fields(self):
+    def test_update_intervention_evidence_fields(self):
         url = reverse("synopsis:project_synopsis_structure", args=[self.project.id])
         chapter = SynopsisChapter.objects.create(
             project=self.project,
@@ -1041,7 +1041,6 @@ class SynopsisStructureTests(TestCase):
                 "intervention_id": intervention.id,
                 "ce_action_url": "https://www.conservationevidence.com/actions/4018",
                 "evidence_status": SynopsisIntervention.EVIDENCE_STATUS_NO_STUDIES,
-                "synthesis_text": "No direct studies were identified in the searched evidence base.",
             },
         )
         self.assertEqual(response.status_code, 302)
@@ -1054,7 +1053,6 @@ class SynopsisStructureTests(TestCase):
             intervention.evidence_status,
             SynopsisIntervention.EVIDENCE_STATUS_NO_STUDIES,
         )
-        self.assertIn("No direct studies", intervention.synthesis_text)
 
     def test_add_and_update_key_message(self):
         url = reverse("synopsis:project_synopsis_structure", args=[self.project.id])

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -1015,7 +1015,7 @@ class SynopsisStructureTests(TestCase):
             SynopsisIntervention.objects.filter(subheading__chapter=text_chapter).exists()
         )
 
-    def test_update_intervention_evidence_fields(self):
+    def test_update_intervention_details_fields(self):
         url = reverse("synopsis:project_synopsis_structure", args=[self.project.id])
         chapter = SynopsisChapter.objects.create(
             project=self.project,
@@ -1037,7 +1037,7 @@ class SynopsisStructureTests(TestCase):
         response = self.client.post(
             url,
             {
-                "action": "update-intervention-synthesis",
+                "action": "update-intervention-details",
                 "intervention_id": intervention.id,
                 "ce_action_url": "https://www.conservationevidence.com/actions/4018",
                 "evidence_status": SynopsisIntervention.EVIDENCE_STATUS_NO_STUDIES,

--- a/src/synopsis/tests.py
+++ b/src/synopsis/tests.py
@@ -912,6 +912,33 @@ class SynopsisStructureTests(TestCase):
         self.assertContains(response, "review the assigned summaries here first")
         self.assertContains(response, "mowing more frequently increased arable plant richness")
 
+    def test_structure_page_background_reference_guidance_is_not_limited_by_search_end_date(self):
+        url = reverse("synopsis:project_synopsis_structure", args=[self.project.id])
+        chapter = SynopsisChapter.objects.create(
+            project=self.project,
+            title="2. Threat: Demo",
+            chapter_type=SynopsisChapter.TYPE_EVIDENCE,
+            position=1,
+        )
+        subheading = SynopsisSubheading.objects.create(
+            chapter=chapter,
+            title="Interventions",
+            position=1,
+        )
+        SynopsisIntervention.objects.create(
+            subheading=subheading,
+            title="2.1 Demo intervention",
+            position=1,
+        )
+
+        response = self.client.get(url)
+
+        self.assertContains(
+            response,
+            "Optional contextual references. These do not need to be published before the search end date.",
+        )
+        self.assertNotContains(response, "published before search end date")
+
     def test_structure_page_renders_restore_state_hooks(self):
         url = reverse("synopsis:project_synopsis_structure", args=[self.project.id])
         chapter = SynopsisChapter.objects.create(

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -9946,8 +9946,8 @@ def reference_summary_detail(request, project_id, summary_id):
                 )
             messages.error(request, "Could not save the summary paragraph draft.")
         if action == "save-paragraph-notes":
+            previous_notes = (summary.paragraph_notes or "").strip()
             if paragraph_notes_form.is_valid():
-                previous_notes = (summary.paragraph_notes or "").strip()
                 updated_summary = paragraph_notes_form.save(commit=False)
                 updated_summary.paragraph_notes = (
                     updated_summary.paragraph_notes or ""

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -97,6 +97,7 @@ from .forms import (
     AdvisoryMemberCustomDataForm,
     ReferenceSummaryAssignmentForm,
     ReferenceSummaryDraftForm,
+    ReferenceSummaryParagraphNotesForm,
     ReferenceSummaryUpdateForm,
     ReferenceSummaryCommentForm,
     ReferenceCommentForm,
@@ -8760,6 +8761,7 @@ def _duplicate_reference_summary(source_summary, user=None):
         key_findings=source_summary.key_findings,
         synopsis_draft=source_summary.synopsis_draft,
         use_custom_synopsis_draft=source_summary.use_custom_synopsis_draft,
+        paragraph_notes=source_summary.paragraph_notes,
         summary_author=summary_author,
         broad_category=source_summary.broad_category,
         keywords=copy.deepcopy(source_summary.keywords or []),
@@ -9672,6 +9674,10 @@ def reference_summary_detail(request, project_id, summary_id):
         instance=summary,
         generated_summary=generated_summary,
     )
+    paragraph_notes_form = ReferenceSummaryParagraphNotesForm(
+        request.POST if active_action == "save-paragraph-notes" else None,
+        instance=summary,
+    )
     comment_form = ReferenceSummaryCommentForm()
     document_form = ReferenceDocumentForm()
     action_summary_form = ReferenceActionSummaryForm()
@@ -9939,6 +9945,51 @@ def reference_summary_detail(request, project_id, summary_id):
                     summary_id=summary.id,
                 )
             messages.error(request, "Could not save the summary paragraph draft.")
+        if action == "save-paragraph-notes":
+            if paragraph_notes_form.is_valid():
+                previous_notes = (summary.paragraph_notes or "").strip()
+                updated_summary = paragraph_notes_form.save(commit=False)
+                updated_summary.paragraph_notes = (
+                    updated_summary.paragraph_notes or ""
+                ).strip()
+                updated_summary.save(update_fields=["paragraph_notes", "updated_at"])
+                current_notes = updated_summary.paragraph_notes
+                _log_summary_history(
+                    project,
+                    request.user,
+                    (
+                        "Summary paragraph notes saved"
+                        if current_notes
+                        else "Summary paragraph notes cleared"
+                    ),
+                    updated_summary,
+                    extra_details=[
+                        (
+                            f"Notes: {_history_safe_text(current_notes, max_length=220)}"
+                            if current_notes
+                            else ""
+                        ),
+                        (
+                            f"Previous notes: {_history_safe_text(previous_notes, max_length=160)}"
+                            if previous_notes and not current_notes
+                            else ""
+                        ),
+                    ],
+                )
+                messages.success(
+                    request,
+                    (
+                        "Internal paragraph notes saved."
+                        if current_notes
+                        else "Internal paragraph notes cleared."
+                    ),
+                )
+                return redirect(
+                    "synopsis:reference_summary_detail",
+                    project_id=project.id,
+                    summary_id=summary.id,
+                )
+            messages.error(request, "Could not save the internal paragraph notes.")
         if action == "update-classification" and classification_form.is_valid():
             reference = summary.reference
             previous_status = reference.screening_status
@@ -10342,6 +10393,7 @@ def reference_summary_detail(request, project_id, summary_id):
             "summary_tabs": summary_tabs,
             "summary_form": summary_form,
             "draft_form": draft_form,
+            "paragraph_notes_form": paragraph_notes_form,
             "assignment_form": assignment_form,
             "classification_form": classification_form,
             "comment_form": comment_form,

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -11006,33 +11006,28 @@ def _project_synopsis_workspace(
                 intervention.evidence_status = synthesis_form.cleaned_data[
                     "evidence_status"
                 ]
-                intervention.synthesis_text = (
-                    synthesis_form.cleaned_data.get("synthesis_text", "") or ""
-                )
                 intervention.save(
                     update_fields=[
                         "ce_action_url",
                         "evidence_status",
-                        "synthesis_text",
                         "updated_at",
                     ]
                 )
                 _log_structure_history(
                     project,
                     request.user,
-                    "Intervention synthesis saved",
+                    "Intervention details saved",
                     chapter=intervention.subheading.chapter,
                     subheading=intervention.subheading,
                     intervention=intervention,
                     extra_details=[
                         f"Evidence status: {intervention.get_evidence_status_display()}",
                         f"CE action link: {'Yes' if intervention.ce_action_url else 'No'}",
-                        f"Synthesis text: {'Yes' if intervention.synthesis_text else 'No'}",
                     ],
                 )
-                messages.success(request, "Intervention synthesis saved.")
+                messages.success(request, "Intervention details saved.")
             else:
-                messages.error(request, "Please check the synthesis fields.")
+                messages.error(request, "Please check the intervention details.")
             return redirect(redirect_url)
         elif action == "add-key-message":
             intervention = _intervention_from_post()
@@ -11840,9 +11835,6 @@ def _generate_synopsis_docx(project):
                     doc.add_paragraph(
                         "We found no studies that evaluated the effects of this intervention."
                     )
-
-                if intervention.synthesis_text:
-                    doc.add_paragraph(intervention.synthesis_text)
 
                 for assignment in ordered_assignments:
                     summary = assignment.reference_summary

--- a/src/synopsis/views.py
+++ b/src/synopsis/views.py
@@ -106,7 +106,7 @@ from .forms import (
     SynopsisSubheadingForm,
     SynopsisInterventionForm,
     SynopsisBackgroundForm,
-    SynopsisInterventionSynthesisForm,
+    SynopsisInterventionDetailsForm,
     SynopsisKeyMessageForm,
     SynopsisAssignmentForm,
     ReferenceActionSummaryForm,
@@ -10496,7 +10496,7 @@ def _project_synopsis_workspace(
         chapter_form.fields["chapter_type"].initial = SynopsisChapter.TYPE_EVIDENCE
     subheading_form = SynopsisSubheadingForm()
     intervention_form = SynopsisInterventionForm(project=project)
-    intervention_synthesis_form = SynopsisInterventionSynthesisForm()
+    intervention_details_form = SynopsisInterventionDetailsForm()
     key_message_form = SynopsisKeyMessageForm()
     assignment_form = SynopsisAssignmentForm(project=project)
     redirect_url = reverse(
@@ -10996,14 +10996,14 @@ def _project_synopsis_workspace(
             else:
                 messages.error(request, "Please check the background fields.")
             return redirect(redirect_url)
-        elif action == "update-intervention-synthesis":
+        elif action == "update-intervention-details":
             intervention = _intervention_from_post()
-            synthesis_form = SynopsisInterventionSynthesisForm(request.POST)
-            if synthesis_form.is_valid():
+            details_form = SynopsisInterventionDetailsForm(request.POST)
+            if details_form.is_valid():
                 intervention.ce_action_url = (
-                    synthesis_form.cleaned_data.get("ce_action_url", "") or ""
+                    details_form.cleaned_data.get("ce_action_url", "") or ""
                 )
-                intervention.evidence_status = synthesis_form.cleaned_data[
+                intervention.evidence_status = details_form.cleaned_data[
                     "evidence_status"
                 ]
                 intervention.save(
@@ -11671,7 +11671,7 @@ def _project_synopsis_workspace(
             "chapter_form": chapter_form,
             "subheading_form": subheading_form,
             "intervention_form": intervention_form,
-            "intervention_synthesis_form": intervention_synthesis_form,
+            "intervention_details_form": intervention_details_form,
             "key_message_form": key_message_form,
             "assignment_form": assignment_form,
             "reference_summaries": reference_summaries,

--- a/src/templates/synopsis/project_synopsis_structure.html
+++ b/src/templates/synopsis/project_synopsis_structure.html
@@ -483,7 +483,7 @@
                                         <div class="fw-semibold mb-1">Intervention evidence details</div>
                                         <form method="post" class="d-flex flex-column gap-2">
                                             {% csrf_token %}
-                                            <input type="hidden" name="action" value="update-intervention-synthesis">
+                                            <input type="hidden" name="action" value="update-intervention-details">
                                             <input type="hidden" name="intervention_id" value="{{ intervention.id }}">
                                             <div class="small text-muted">The compiled synopsis uses the intervention background, any key messages, and then the assigned study summary paragraphs. These fields are kept only as intervention metadata and do not add extra narrative text to the compiled synopsis.</div>
                                             <div class="row g-2">
@@ -494,7 +494,7 @@
                                                 <div class="col-12 col-lg-3">
                                                     <label class="form-label small text-muted mb-1">Evidence status</label>
                                                     <select name="evidence_status" class="form-select form-select-sm">
-                                                        {% for code, label in intervention_synthesis_form.evidence_status.field.choices %}
+                                                        {% for code, label in intervention_details_form.evidence_status.field.choices %}
                                                             {% if intervention.evidence_status == code %}
                                                                 <option value="{{ code }}" selected>{{ label }}</option>
                                                             {% else %}

--- a/src/templates/synopsis/project_synopsis_structure.html
+++ b/src/templates/synopsis/project_synopsis_structure.html
@@ -480,12 +480,12 @@
                                         </form>
 
                                         <hr>
-                                        <div class="fw-semibold mb-1">Optional intervention text</div>
+                                        <div class="fw-semibold mb-1">Intervention evidence details</div>
                                         <form method="post" class="d-flex flex-column gap-2">
                                             {% csrf_token %}
                                             <input type="hidden" name="action" value="update-intervention-synthesis">
                                             <input type="hidden" name="intervention_id" value="{{ intervention.id }}">
-                                            <div class="small text-muted">Use this only if you need extra text for the whole intervention. It appears after key messages and before the study paragraphs in the compiled synopsis. Most content should be added as background, key messages or assigned summaries.</div>
+                                            <div class="small text-muted">The compiled synopsis uses the intervention background, any key messages, and then the assigned study summary paragraphs. These fields are kept only as intervention metadata and do not add extra narrative text to the compiled synopsis.</div>
                                             <div class="row g-2">
                                                 <div class="col-12 col-lg-6">
                                                     <label class="form-label small text-muted mb-1">Conservation Evidence action URL</label>
@@ -504,10 +504,8 @@
                                                     </select>
                                                 </div>
                                             </div>
-                                            <label class="form-label small text-muted mb-1">Additional intervention text</label>
-                                            <textarea name="synthesis_text" class="form-control form-control-sm" rows="4" placeholder="Optional text that should appear after key messages and before study paragraphs.">{{ intervention.synthesis_text }}</textarea>
                                             <div class="d-flex justify-content-end">
-                                                <button class="btn btn-outline-primary btn-sm">Save intervention text</button>
+                                                <button class="btn btn-outline-primary btn-sm">Save intervention details</button>
                                             </div>
                                         </form>
 

--- a/src/templates/synopsis/project_synopsis_structure.html
+++ b/src/templates/synopsis/project_synopsis_structure.html
@@ -259,7 +259,8 @@
                         </div>
                         {% if chapter.supports_evidence_structure %}
                             <div class="mb-2">
-                                <textarea name="background_references" class="form-control form-control-sm" rows="2" placeholder="Background references (one per line, published before search end date).">{{ chapter.background_references }}</textarea>
+                                <textarea name="background_references" class="form-control form-control-sm" rows="2" placeholder="Background references (one per line, optional contextual sources; not limited by the search end date).">{{ chapter.background_references }}</textarea>
+                                <div class="form-text">Optional contextual references. These do not need to be published before the search end date.</div>
                             </div>
                             <button class="btn btn-outline-primary btn-sm">Save background</button>
                         {% else %}
@@ -471,7 +472,8 @@
                                             <input type="hidden" name="intervention_id" value="{{ intervention.id }}">
                                             <div class="small text-muted">Appears before key messages/studies in the intervention section.</div>
                                             <textarea name="background_text" class="form-control form-control-sm" rows="3" placeholder="Background (<200 words): describe the intervention, context, related literature/harms.">{{ intervention.background_text }}</textarea>
-                                            <textarea name="background_references" class="form-control form-control-sm" rows="2" placeholder="Background references (one per line, published before search end date).">{{ intervention.background_references }}</textarea>
+                                            <textarea name="background_references" class="form-control form-control-sm" rows="2" placeholder="Background references (one per line, optional contextual sources; not limited by the search end date).">{{ intervention.background_references }}</textarea>
+                                            <div class="form-text">Optional contextual references. These do not need to be published before the search end date.</div>
                                             <div class="d-flex justify-content-end">
                                                 <button class="btn btn-outline-primary btn-sm">Save background</button>
                                             </div>

--- a/src/templates/synopsis/reference_summary_detail.html
+++ b/src/templates/synopsis/reference_summary_detail.html
@@ -835,6 +835,25 @@
                         {% endif %}
                     </div>
                 </form>
+                <hr class="my-4">
+                <form method="post" class="d-flex flex-column gap-3" id="paragraph-notes-form">
+                    {% csrf_token %}
+                    <input type="hidden" name="action" value="save-paragraph-notes">
+                    <div>
+                        <label class="form-label" for="{{ paragraph_notes_form.paragraph_notes.id_for_label }}">Internal notes on this paragraph</label>
+                        {{ paragraph_notes_form.paragraph_notes }}
+                        <div class="form-text">{{ paragraph_notes_form.paragraph_notes.help_text }}</div>
+                        {% if paragraph_notes_form.paragraph_notes.errors %}
+                        <div class="text-danger small">{{ paragraph_notes_form.paragraph_notes.errors|join:", " }}</div>
+                        {% endif %}
+                    </div>
+                    <div class="d-flex flex-wrap gap-2 align-items-center">
+                        <button class="btn btn-outline-primary btn-sm" type="submit">Save paragraph notes</button>
+                        {% if summary.paragraph_notes %}
+                        <span class="small text-muted">Saved only in the portal. Not included in synopsis exports.</span>
+                        {% endif %}
+                    </div>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Pull Request
<!-- Please fill out the following sections to the best of your ability. You may skip any sections that are not mandatory or relevant by putting 'N/A' inside the sub-section. -->

_Please answer the following sections before submitting your PR:_

## Type of Change
<!-- Mandatory -->
- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues
<!-- Mandatory -->
Fixes #(issue number)
Addresses #(issue number)
Enhancements #(issue number)

#### 1 Why was this PR needed?
Adds a new per-summary “internal paragraph notes” field to the Synopsis Portal so authors can save private context about a reference summary paragraph (persisted in the DB, editable from the detail page, and captured in project change history).

#### 2 What changed?
Changes:

- Added paragraph_notes to ReferenceSummary (model + migration) and ensured it’s copied when duplicating a summary tab.
- Implemented UI + form handling on the reference summary detail page to save/clear notes with history logging.
- Added/updated tests to cover rendering, persistence, duplication, and change-log behavior.
- Update wording to clarify that background references are optional contextual sources and are not limited by the search end date. 

#### 3 Backward compatibility & risk
N/A

#### 4 Files changed
See files changed.

#### 5 Other changes
N/A

## Testing & Results
<!-- Mandatory -->
All tests passed and added new ones.

## Checklist
<!-- Mandatory -->
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my changes work
- [x] All new and existing tests pass
- [x] My changes follow the established code style guidelines

## Screenshots (if applicable)
<!-- Optional -->
_Add screenshots here if needed_

## Notes
<!-- Optional -->
e.g. additional information, context, or comments for reviewers.